### PR TITLE
fix(core): retry locate responses with missing coordinates

### DIFF
--- a/packages/core/src/ai-model/model-adapter/default-locate-protocol.ts
+++ b/packages/core/src/ai-model/model-adapter/default-locate-protocol.ts
@@ -138,10 +138,12 @@ const createParseRawResponse =
           ? record.bbox_2d
           : undefined;
     const error = typeof record.error === 'string' ? record.error : undefined;
-    const hasTarget = Array.isArray(target)
-      ? target.length > 0
-      : target !== undefined;
-    if (!hasTarget) {
+    if (target === undefined) {
+      throw new Error(
+        `Missing required coordinate field "${promptSpec.resultKey}". Expected "${promptSpec.resultKey}": ${promptSpec.resultValueSchema}; use an empty array when no element is found.${error ? ` Model error: ${error}` : ''}`,
+      );
+    }
+    if (Array.isArray(target) && target.length === 0) {
       return { kind: 'not-found', ...(error ? { error } : {}) };
     }
 

--- a/packages/core/tests/unit-test/grounding-locate-not-found.test.ts
+++ b/packages/core/tests/unit-test/grounding-locate-not-found.test.ts
@@ -35,37 +35,57 @@ describe('grounding locate not-found parsing', () => {
     rs.mocked(callAI).mockResolvedValue({ content: '{}', isStreamed: false });
   });
 
-  it('keeps locate errors without parsing coordinates when result key is missing', async () => {
-    rs.mocked(callAI).mockResolvedValue({
-      content: '{"error":"target element is not found"}',
-      isStreamed: false,
-    });
+  it.each([
+    '{}',
+    '{"error":"target element is not found"}',
+    '```json\n[{"bbox_1":920,"ymin":73,"xmax":964,"ymax":98}]\n```',
+  ])('retries a response missing the coordinate field: %s', async (content) => {
+    rs.mocked(callAI)
+      .mockResolvedValueOnce({ content, isStreamed: false })
+      .mockResolvedValueOnce({
+        content: '{"bbox":[100,200,300,400]}',
+        isStreamed: false,
+      });
 
     const result = await AiLocateElement({
       context: createFakeContext(),
-      targetElementDescription: 'missing button',
-      modelRuntime: getModelRuntime(modelConfig),
+      targetElementDescription: 'top-right menu button',
+      modelRuntime: getModelRuntime({ ...modelConfig, modelFamily: 'qwen3' }),
     });
 
-    expect(result.rect).toBeUndefined();
-    expect(result.parseResult).toEqual({
-      element: undefined,
-      errors: ['target element is not found'],
-    });
+    expect(callAI).toHaveBeenCalledTimes(2);
+    expect(rs.mocked(callAI).mock.calls.map((call) => call[2])).toEqual([
+      expect.objectContaining({ semanticRetryAttempt: 0 }),
+      expect.objectContaining({ semanticRetryAttempt: 1 }),
+    ]);
+    const retryFeedback = rs.mocked(callAI).mock.calls[1][0].at(-1);
+    expect(retryFeedback?.content).toContain(
+      'Missing required coordinate field "bbox"',
+    );
+    expect(retryFeedback?.content).toContain('Expected "bbox":');
+    expect(result.rect).toBeDefined();
+    expect(result.parseResult.errors).toEqual([]);
   });
 
-  it('skips coordinate parsing when result key is missing even without errors', async () => {
+  it('preserves the missing-field error and response after retries are exhausted', async () => {
+    const content = '{"error":"target element is not found"}';
+    rs.mocked(callAI).mockResolvedValue({ content, isStreamed: false });
+
     const result = await AiLocateElement({
       context: createFakeContext(),
       targetElementDescription: 'missing button',
       modelRuntime: getModelRuntime(modelConfig),
     });
 
+    expect(callAI).toHaveBeenCalledTimes(2);
     expect(result.rect).toBeUndefined();
-    expect(result.parseResult).toEqual({
-      element: undefined,
-      errors: [],
-    });
+    expect(result.parseResult.errors?.[0]).toContain(
+      'Missing required coordinate field "bbox"',
+    );
+    expect(result.parseResult.errors?.[0]).toContain(
+      'target element is not found',
+    );
+    expect(result.rawResponse).toBe(content);
   });
 
   it('skips coordinate parsing when result key is an empty array', async () => {
@@ -80,6 +100,7 @@ describe('grounding locate not-found parsing', () => {
       modelRuntime: getModelRuntime(modelConfig),
     });
 
+    expect(callAI).toHaveBeenCalledTimes(1);
     expect(result.rect).toBeUndefined();
     expect(result.parseResult).toEqual({
       element: undefined,
@@ -261,20 +282,29 @@ describe('grounding locate not-found parsing', () => {
     expect(result.reasoning_content).toBe('custom reasoning');
   });
 
-  it('keeps section locate error without parsing coordinates when result key is missing', async () => {
-    rs.mocked(callAI).mockResolvedValue({
-      content: '{"error":"target section is not found"}',
-      isStreamed: false,
-    });
+  it('retries a search-area response missing the coordinate field', async () => {
+    rs.mocked(callAI)
+      .mockResolvedValueOnce({
+        content: '{"error":"target section is not found"}',
+        isStreamed: false,
+      })
+      .mockResolvedValueOnce({
+        content: '{"bbox":[100,200,300,400]}',
+        isStreamed: false,
+      });
 
     const result = await AiLocateSection({
       context: createFakeContext(),
-      sectionDescription: 'missing section',
+      sectionDescription: 'target section',
       modelRuntime: getModelRuntime(modelConfig),
     });
 
-    expect(result.searchAreaConfig).toBeUndefined();
-    expect(result.error).toBe('target section is not found');
+    expect(callAI).toHaveBeenCalledTimes(2);
+    const retryFeedback = rs.mocked(callAI).mock.calls[1][0].at(-1);
+    expect(retryFeedback?.content).toContain(
+      'Missing required coordinate field "bbox"',
+    );
+    expect(result.searchAreaConfig).toBeDefined();
   });
 
   it('keeps section locate error without parsing coordinates when result key is an empty array', async () => {
@@ -289,6 +319,7 @@ describe('grounding locate not-found parsing', () => {
       modelRuntime: getModelRuntime(modelConfig),
     });
 
+    expect(callAI).toHaveBeenCalledTimes(1);
     expect(result.searchAreaConfig).toBeUndefined();
     expect(result.error).toBe('target section is not found');
   });

--- a/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
@@ -103,14 +103,12 @@ describe('default locate protocol', () => {
       normalizedBy: 1000,
     });
 
-    expect(
+    expect(() =>
       elementProtocol.parseRawResponse(
         '{"bbox_2d":[100,200,300,400]}',
         locatePromptSpec,
       ),
-    ).toEqual({
-      kind: 'not-found',
-    });
+    ).toThrow('Missing required coordinate field "bbox"');
     expect(
       elementProtocol.parseRawResponse(
         '{"bbox":[100,200,300,400],"bbox_2d":[500,600,700,800]}',


### PR DESCRIPTION
Locate responses with missing coordinate fields were treated as `not-found`, so malformed output such as `[{"bbox_1":920,"ymin":73,"xmax":964,"ymax":98}]` bypassed parsing retries and ended with `Element not found`.

Require the expected coordinate field in the default element and search-area protocols. Missing fields now trigger the existing semantic retry loop with feedback describing the expected format; explicit empty coordinate arrays still mean not found. Regression tests cover malformed responses, successful retries, exhausted retries retaining the error and raw response, and empty arrays making only one call.

Validation:
- `pnpm run lint`
- `pnpm exec nx test @midscene/core -- tests/unit-test/grounding-locate-not-found.test.ts tests/unit-test/model-adapter/default-locate-protocol.test.ts tests/unit-test/locate-normalization.test.ts tests/unit-test/section-locate-protocol.test.ts` — 23 tests passed
- `pnpm exec nx build @midscene/core`
- `pnpm exec commitlint` — validated the commit title via stdin