### PR TITLE
fix(computer): smooth native drag trajectory

### DIFF
--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -33,6 +33,41 @@ env:
   ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
 jobs:
+  headless-linux-drag-and-drop:
+    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    env:
+      MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
+      CI: "1"
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        ref: ${{ github.event.inputs.branch || github.ref }}
+
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-node-pnpm
+
+    - name: Cache pnpm store
+      id: pnpm-cache
+      uses: ./.github/actions/pnpm-cache/restore
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile --ignore-scripts
+
+    - name: Save pnpm store
+      if: steps.pnpm-cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/pnpm-cache/save
+
+    - name: Setup headless browser
+      uses: ./.github/actions/setup-headless-browser
+
+    - name: Build computer projects
+      run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache
+
+    - name: Run Linux drag-and-drop regression
+      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/linux-drag-and-drop.test.ts
+      timeout-minutes: 10
+
   headless-linux-ai-todo:
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   headless-linux-drag-and-drop:
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    runs-on: ubuntu-22.04
     env:
       MIDSCENE_COMPUTER_HEADLESS_LINUX: "true"
       CI: "1"

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -21,6 +21,14 @@ on:
         required: false
         default: 'main'
         type: string
+      suite:
+        description: 'Jobs to run'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - drag-only
 
 permissions:
   contents: read
@@ -69,6 +77,7 @@ jobs:
       timeout-minutes: 10
 
   headless-linux-ai-todo:
+    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'drag-only'
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
@@ -138,6 +147,7 @@ jobs:
       run: exit 1
 
   chrome-extension:
+    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'drag-only'
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       # Env vars for computer agent (screenshot + AI actions)
@@ -197,6 +207,7 @@ jobs:
       run: exit 1
 
   chrome-extension-bridge:
+    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'drag-only'
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
@@ -254,6 +265,7 @@ jobs:
       run: exit 1
 
   chrome-extension-playground:
+    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'drag-only'
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     strategy:
       fail-fast: false
@@ -319,6 +331,7 @@ jobs:
       run: exit 1
 
   chrome-extension-recorder:
+    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'drag-only'
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}
@@ -376,6 +389,7 @@ jobs:
       run: exit 1
 
   chrome-extension-settings:
+    if: github.event_name != 'workflow_dispatch' || inputs.suite != 'drag-only'
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     env:
       MIDSCENE_MODEL_API_KEY: ${{ secrets.MIDSCENE_MODEL_API_KEY }}

--- a/.github/workflows/headless-linux.yml
+++ b/.github/workflows/headless-linux.yml
@@ -73,7 +73,10 @@ jobs:
       run: pnpm exec nx run-many --target=build --projects="@midscene/report,@midscene/computer" --skip-nx-cache
 
     - name: Run Linux drag-and-drop regression
-      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/linux-drag-and-drop.test.ts
+      # libnut keeps a process-wide X11 connection. Retrying after the test
+      # tears down Xvfb would terminate the worker before it can report the
+      # original assertion, so this live-display regression runs once.
+      run: AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/linux-drag-and-drop.test.ts --retry 0
       timeout-minutes: 10
 
   headless-linux-ai-todo:

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -116,8 +116,10 @@ export interface Point {
 // Constants
 const SMOOTH_MOVE_STEPS_TAP = 8;
 const SMOOTH_MOVE_STEPS_MOUSE_MOVE = 10;
+const SMOOTH_MOVE_STEPS_DRAG = 20;
 const SMOOTH_MOVE_DELAY_TAP = 8;
 const SMOOTH_MOVE_DELAY_MOUSE_MOVE = 10;
+const SMOOTH_MOVE_DELAY_DRAG = 10;
 const MOUSE_MOVE_EFFECT_WAIT = 300;
 const CLICK_SETTLE_DELAY = 50;
 const CLICK_HOLD_DURATION = 100;
@@ -971,6 +973,14 @@ export class ComputerDevice implements AbstractInterface {
           await this.moveDisplayPointer(
             to,
             'Mouse did not reach the drag end target',
+            {
+              // Native desktop toolkits commonly use the first motion beyond
+              // their threshold to enter drag mode. Keep emitting held-button
+              // motions so the drop target can observe the active drag before
+              // the button is released.
+              smoothSteps: SMOOTH_MOVE_STEPS_DRAG,
+              smoothDelay: SMOOTH_MOVE_DELAY_DRAG,
+            },
           );
           await this.inputDriver.delay(100);
         });

--- a/packages/computer/tests/ai/fixtures/linux-drag-and-drop.html
+++ b/packages/computer/tests/ai/fixtures/linux-drag-and-drop.html
@@ -107,7 +107,11 @@
         }
       });
 
-      report('ready');
+      const viewportLeft = window.screenX + (window.outerWidth - window.innerWidth) / 2;
+      const viewportTop = window.screenY + window.outerHeight - window.innerHeight;
+      fetch(`/ready?left=${viewportLeft}&top=${viewportTop}`, {
+        method: 'POST',
+      }).catch(() => {});
     </script>
   </body>
 </html>

--- a/packages/computer/tests/ai/fixtures/linux-drag-and-drop.html
+++ b/packages/computer/tests/ai/fixtures/linux-drag-and-drop.html
@@ -58,8 +58,15 @@
       let startX = 0;
       let startY = 0;
 
-      const report = (event) => {
-        fetch(`/event?name=${event}`, { method: 'POST' }).catch(() => {});
+      const report = (name, event) => {
+        const params = new URLSearchParams({ name });
+        if (event) {
+          params.set('x', event.clientX);
+          params.set('y', event.clientY);
+          params.set('buttons', event.buttons);
+          params.set('element', document.elementFromPoint(event.clientX, event.clientY)?.id || '');
+        }
+        fetch(`/event?${params}`, { method: 'POST' }).catch(() => {});
       };
 
       source.addEventListener('mousedown', (event) => {
@@ -67,7 +74,7 @@
         startX = event.clientX;
         startY = event.clientY;
         status.textContent = 'Pressed';
-        report('pressed');
+        report('pressed', event);
       });
 
       document.addEventListener('mousemove', (event) => {
@@ -79,7 +86,7 @@
           // enter drag mode. The drop target can only observe later motions.
           dragStarted = true;
           status.textContent = 'Dragging';
-          report('drag-started');
+          report('drag-started', event);
           return;
         }
 
@@ -87,7 +94,7 @@
           targetObservedAfterDragStart = true;
           target.style.background = '#4ade80';
           status.textContent = 'Target observed';
-          report('target-observed');
+          report('target-observed', event);
         }
       });
 
@@ -100,18 +107,39 @@
         );
         if (dragStarted && targetObservedAfterDragStart && releasedOnTarget) {
           status.textContent = 'Dropped';
-          report('dropped');
+          report('dropped', event);
         } else {
           status.textContent = 'Drop missed';
-          report('drop-missed');
+          report('drop-missed', event);
         }
       });
 
-      const viewportLeft = window.screenX + (window.outerWidth - window.innerWidth) / 2;
-      const viewportTop = window.screenY + window.outerHeight - window.innerHeight;
-      fetch(`/ready?left=${viewportLeft}&top=${viewportTop}`, {
-        method: 'POST',
-      }).catch(() => {});
+      for (const type of ['mousedown', 'mousemove', 'mouseup']) {
+        document.addEventListener(type, (event) => report(`raw-${type}`, event), true);
+      }
+
+      // Chromium can report its initial, pre-maximize window geometry during
+      // the first animation frames on Xvfb. Wait for the native window to
+      // settle, then send element centers in display coordinates to the test.
+      setTimeout(() => {
+        const viewportLeft = window.screenX + (window.outerWidth - window.innerWidth) / 2;
+        const viewportTop = window.screenY + window.outerHeight - window.innerHeight;
+        const sourceRect = source.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+        const params = new URLSearchParams({
+          left: viewportLeft,
+          top: viewportTop,
+          sourceX: viewportLeft + sourceRect.left + sourceRect.width / 2,
+          sourceY: viewportTop + sourceRect.top + sourceRect.height / 2,
+          targetX: viewportLeft + targetRect.left + targetRect.width / 2,
+          targetY: viewportTop + targetRect.top + targetRect.height / 2,
+          innerWidth: window.innerWidth,
+          innerHeight: window.innerHeight,
+          outerWidth: window.outerWidth,
+          outerHeight: window.outerHeight,
+        });
+        fetch(`/ready?${params}`, { method: 'POST' }).catch(() => {});
+      }, 1000);
     </script>
   </body>
 </html>

--- a/packages/computer/tests/ai/fixtures/linux-drag-and-drop.html
+++ b/packages/computer/tests/ai/fixtures/linux-drag-and-drop.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Linux drag-and-drop regression fixture</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: #f4f4f5;
+        font: 24px sans-serif;
+      }
+
+      .item {
+        position: absolute;
+        left: 240px;
+        display: grid;
+        width: 240px;
+        height: 140px;
+        place-items: center;
+        border: 4px solid #18181b;
+        border-radius: 12px;
+        user-select: none;
+      }
+
+      #target {
+        top: 60px;
+        background: #bbf7d0;
+      }
+
+      #source {
+        top: 330px;
+        background: #bfdbfe;
+      }
+
+      #status {
+        position: absolute;
+        top: 520px;
+        left: 240px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="target" class="item">Target folder</div>
+    <div id="source" class="item">Source file</div>
+    <div id="status">Waiting</div>
+
+    <script>
+      const source = document.querySelector('#source');
+      const target = document.querySelector('#target');
+      const status = document.querySelector('#status');
+      let pointerDown = false;
+      let dragStarted = false;
+      let targetObservedAfterDragStart = false;
+      let startX = 0;
+      let startY = 0;
+
+      const report = (event) => {
+        fetch(`/event?name=${event}`, { method: 'POST' }).catch(() => {});
+      };
+
+      source.addEventListener('mousedown', (event) => {
+        pointerDown = true;
+        startX = event.clientX;
+        startY = event.clientY;
+        status.textContent = 'Pressed';
+        report('pressed');
+      });
+
+      document.addEventListener('mousemove', (event) => {
+        if (!pointerDown || event.buttons !== 1) return;
+
+        const distance = Math.hypot(event.clientX - startX, event.clientY - startY);
+        if (!dragStarted && distance >= 8) {
+          // Desktop toolkits use the first motion beyond their threshold to
+          // enter drag mode. The drop target can only observe later motions.
+          dragStarted = true;
+          status.textContent = 'Dragging';
+          report('drag-started');
+          return;
+        }
+
+        if (dragStarted && target.contains(document.elementFromPoint(event.clientX, event.clientY))) {
+          targetObservedAfterDragStart = true;
+          target.style.background = '#4ade80';
+          status.textContent = 'Target observed';
+          report('target-observed');
+        }
+      });
+
+      document.addEventListener('mouseup', (event) => {
+        if (!pointerDown) return;
+        pointerDown = false;
+
+        const releasedOnTarget = target.contains(
+          document.elementFromPoint(event.clientX, event.clientY),
+        );
+        if (dragStarted && targetObservedAfterDragStart && releasedOnTarget) {
+          status.textContent = 'Dropped';
+          report('dropped');
+        } else {
+          status.textContent = 'Drop missed';
+          report('drop-missed');
+        }
+      });
+
+      report('ready');
+    </script>
+  </body>
+</html>

--- a/packages/computer/tests/ai/linux-drag-and-drop.test.ts
+++ b/packages/computer/tests/ai/linux-drag-and-drop.test.ts
@@ -1,0 +1,114 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { readFileSync, rmSync } from 'node:fs';
+import { type Server, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from '@rstest/core';
+import { ComputerDevice } from '../../src';
+import { findLinuxBrowser, isHeadlessLinux } from './test-utils';
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures/linux-drag-and-drop.html');
+const SOURCE_CENTER = { x: 360, y: 400 };
+const TARGET_CENTER = { x: 360, y: 130 };
+
+async function waitFor(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+describe.runIf(isHeadlessLinux())('Linux drag and drop', () => {
+  let browser: ChildProcess | undefined;
+  let device: ComputerDevice | undefined;
+  let server: Server | undefined;
+  let browserProfile: string | undefined;
+
+  afterEach(async () => {
+    if (browser && browser.exitCode === null) {
+      browser.kill('SIGTERM');
+      await Promise.race([
+        once(browser, 'exit'),
+        new Promise((resolve) => setTimeout(resolve, 5_000)),
+      ]);
+    }
+    await device?.destroy();
+    if (server?.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+    if (browserProfile) {
+      rmSync(browserProfile, { force: true, recursive: true });
+    }
+  });
+
+  it('delivers a held-pointer motion after drag activation', async () => {
+    const observedEvents = new Set<string>();
+    const fixture = readFileSync(FIXTURE_PATH, 'utf8');
+    server = createServer((request, response) => {
+      const url = new URL(request.url || '/', 'http://127.0.0.1');
+      if (url.pathname === '/event') {
+        observedEvents.add(url.searchParams.get('name') || 'unknown');
+        response.writeHead(204).end();
+        return;
+      }
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      response.end(fixture);
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Drag fixture server did not bind a TCP port');
+    }
+
+    device = new ComputerDevice({ headless: true });
+    await device.connect();
+
+    browserProfile = path.join(
+      tmpdir(),
+      `midscene-linux-drag-${process.pid}-${Date.now()}`,
+    );
+    browser = spawn(
+      findLinuxBrowser(),
+      [
+        '--no-sandbox',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-extensions',
+        '--kiosk',
+        '--window-position=0,0',
+        '--window-size=1920,1080',
+        `--user-data-dir=${browserProfile}`,
+        `http://127.0.0.1:${address.port}`,
+      ],
+      { env: process.env, stdio: 'ignore' },
+    );
+
+    await waitFor(() => observedEvents.has('ready'), 'browser fixture');
+    await device.inputPrimitives.pointer!.dragAndDrop(
+      SOURCE_CENTER,
+      TARGET_CENTER,
+    );
+    await waitFor(
+      () => observedEvents.has('dropped') || observedEvents.has('drop-missed'),
+      'drag result',
+    );
+
+    expect([...observedEvents]).toContain('drag-started');
+    expect([...observedEvents]).toContain('target-observed');
+    expect([...observedEvents]).toContain('dropped');
+    expect([...observedEvents]).not.toContain('drop-missed');
+  });
+});

--- a/packages/computer/tests/ai/linux-drag-and-drop.test.ts
+++ b/packages/computer/tests/ai/linux-drag-and-drop.test.ts
@@ -9,8 +9,18 @@ import { ComputerDevice } from '../../src';
 import { findLinuxBrowser, isHeadlessLinux } from './test-utils';
 
 const FIXTURE_PATH = path.join(__dirname, 'fixtures/linux-drag-and-drop.html');
-const SOURCE_CENTER_IN_VIEWPORT = { x: 360, y: 400 };
-const TARGET_CENTER_IN_VIEWPORT = { x: 360, y: 130 };
+
+interface BrowserGeometry {
+  source: { x: number; y: number };
+  target: { x: number; y: number };
+  viewport: { left: number; top: number };
+  window: {
+    innerWidth: number;
+    innerHeight: number;
+    outerWidth: number;
+    outerHeight: number;
+  };
+}
 
 async function waitFor(
   predicate: () => boolean,
@@ -52,22 +62,38 @@ describe.runIf(isHeadlessLinux())('Linux drag and drop', () => {
   });
 
   it('delivers a held-pointer motion after drag activation', async () => {
-    const observedEvents = new Set<string>();
-    let viewportOrigin: { x: number; y: number } | undefined;
+    const observedEvents: string[] = [];
+    let browserGeometry: BrowserGeometry | undefined;
     let browserStderr = '';
     const fixture = readFileSync(FIXTURE_PATH, 'utf8');
     server = createServer((request, response) => {
       const url = new URL(request.url || '/', 'http://127.0.0.1');
       if (url.pathname === '/ready') {
-        viewportOrigin = {
-          x: Number(url.searchParams.get('left')),
-          y: Number(url.searchParams.get('top')),
+        browserGeometry = {
+          source: {
+            x: Number(url.searchParams.get('sourceX')),
+            y: Number(url.searchParams.get('sourceY')),
+          },
+          target: {
+            x: Number(url.searchParams.get('targetX')),
+            y: Number(url.searchParams.get('targetY')),
+          },
+          viewport: {
+            left: Number(url.searchParams.get('left')),
+            top: Number(url.searchParams.get('top')),
+          },
+          window: {
+            innerWidth: Number(url.searchParams.get('innerWidth')),
+            innerHeight: Number(url.searchParams.get('innerHeight')),
+            outerWidth: Number(url.searchParams.get('outerWidth')),
+            outerHeight: Number(url.searchParams.get('outerHeight')),
+          },
         };
         response.writeHead(204).end();
         return;
       }
       if (url.pathname === '/event') {
-        observedEvents.add(url.searchParams.get('name') || 'unknown');
+        observedEvents.push(url.searchParams.toString());
         response.writeHead(204).end();
         return;
       }
@@ -115,25 +141,32 @@ describe.runIf(isHeadlessLinux())('Linux drag and drop', () => {
           `Browser exited before loading the fixture (code=${browser?.exitCode}): ${browserStderr}`,
         );
       }
-      return !!viewportOrigin;
+      return !!browserGeometry;
     }, 'browser fixture');
-    const source = {
-      x: viewportOrigin!.x + SOURCE_CENTER_IN_VIEWPORT.x,
-      y: viewportOrigin!.y + SOURCE_CENTER_IN_VIEWPORT.y,
-    };
-    const target = {
-      x: viewportOrigin!.x + TARGET_CENTER_IN_VIEWPORT.x,
-      y: viewportOrigin!.y + TARGET_CENTER_IN_VIEWPORT.y,
-    };
+    const { source, target } = browserGeometry!;
     await device.inputPrimitives.pointer!.dragAndDrop(source, target);
-    await waitFor(
-      () => observedEvents.has('dropped') || observedEvents.has('drop-missed'),
-      'drag result',
-    );
+    try {
+      await waitFor(
+        () =>
+          observedEvents.some(
+            (event) =>
+              event.startsWith('name=dropped') ||
+              event.startsWith('name=drop-missed'),
+          ),
+        'drag result',
+      );
+    } catch (error) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; geometry=${JSON.stringify(browserGeometry)}; events=${JSON.stringify(observedEvents)}; browserStderr=${browserStderr}`,
+      );
+    }
 
-    expect([...observedEvents]).toContain('drag-started');
-    expect([...observedEvents]).toContain('target-observed');
-    expect([...observedEvents]).toContain('dropped');
-    expect([...observedEvents]).not.toContain('drop-missed');
+    const eventNames = observedEvents.map(
+      (event) => new URLSearchParams(event).get('name') || 'unknown',
+    );
+    expect(eventNames).toContain('drag-started');
+    expect(eventNames).toContain('target-observed');
+    expect(eventNames).toContain('dropped');
+    expect(eventNames).not.toContain('drop-missed');
   });
 });

--- a/packages/computer/tests/ai/linux-drag-and-drop.test.ts
+++ b/packages/computer/tests/ai/linux-drag-and-drop.test.ts
@@ -9,8 +9,8 @@ import { ComputerDevice } from '../../src';
 import { findLinuxBrowser, isHeadlessLinux } from './test-utils';
 
 const FIXTURE_PATH = path.join(__dirname, 'fixtures/linux-drag-and-drop.html');
-const SOURCE_CENTER = { x: 360, y: 400 };
-const TARGET_CENTER = { x: 360, y: 130 };
+const SOURCE_CENTER_IN_VIEWPORT = { x: 360, y: 400 };
+const TARGET_CENTER_IN_VIEWPORT = { x: 360, y: 130 };
 
 async function waitFor(
   predicate: () => boolean,
@@ -53,9 +53,19 @@ describe.runIf(isHeadlessLinux())('Linux drag and drop', () => {
 
   it('delivers a held-pointer motion after drag activation', async () => {
     const observedEvents = new Set<string>();
+    let viewportOrigin: { x: number; y: number } | undefined;
+    let browserStderr = '';
     const fixture = readFileSync(FIXTURE_PATH, 'utf8');
     server = createServer((request, response) => {
       const url = new URL(request.url || '/', 'http://127.0.0.1');
+      if (url.pathname === '/ready') {
+        viewportOrigin = {
+          x: Number(url.searchParams.get('left')),
+          y: Number(url.searchParams.get('top')),
+        };
+        response.writeHead(204).end();
+        return;
+      }
       if (url.pathname === '/event') {
         observedEvents.add(url.searchParams.get('name') || 'unknown');
         response.writeHead(204).end();
@@ -79,7 +89,7 @@ describe.runIf(isHeadlessLinux())('Linux drag and drop', () => {
       `midscene-linux-drag-${process.pid}-${Date.now()}`,
     );
     browser = spawn(
-      findLinuxBrowser(),
+      process.env.PUPPETEER_EXECUTABLE_PATH || findLinuxBrowser(),
       [
         '--no-sandbox',
         '--disable-gpu',
@@ -87,20 +97,35 @@ describe.runIf(isHeadlessLinux())('Linux drag and drop', () => {
         '--no-first-run',
         '--no-default-browser-check',
         '--disable-extensions',
-        '--kiosk',
         '--window-position=0,0',
         '--window-size=1920,1080',
+        '--start-maximized',
         `--user-data-dir=${browserProfile}`,
         `http://127.0.0.1:${address.port}`,
       ],
-      { env: process.env, stdio: 'ignore' },
+      { env: process.env, stdio: ['ignore', 'ignore', 'pipe'] },
     );
+    browser.stderr?.on('data', (chunk: Buffer) => {
+      browserStderr += chunk.toString();
+    });
 
-    await waitFor(() => observedEvents.has('ready'), 'browser fixture');
-    await device.inputPrimitives.pointer!.dragAndDrop(
-      SOURCE_CENTER,
-      TARGET_CENTER,
-    );
+    await waitFor(() => {
+      if (browser?.exitCode !== null) {
+        throw new Error(
+          `Browser exited before loading the fixture (code=${browser?.exitCode}): ${browserStderr}`,
+        );
+      }
+      return !!viewportOrigin;
+    }, 'browser fixture');
+    const source = {
+      x: viewportOrigin!.x + SOURCE_CENTER_IN_VIEWPORT.x,
+      y: viewportOrigin!.y + SOURCE_CENTER_IN_VIEWPORT.y,
+    };
+    const target = {
+      x: viewportOrigin!.x + TARGET_CENTER_IN_VIEWPORT.x,
+      y: viewportOrigin!.y + TARGET_CENTER_IN_VIEWPORT.y,
+    };
+    await device.inputPrimitives.pointer!.dragAndDrop(source, target);
     await waitFor(
       () => observedEvents.has('dropped') || observedEvents.has('drop-missed'),
       'drag result',

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -387,6 +387,36 @@ describe('ComputerDevice pointer input', () => {
     expect(mockState.libnut.getMousePos).toHaveBeenCalledTimes(2);
   });
 
+  it('emits intermediate held-pointer movements during drag and drop', async () => {
+    const device = await createConnectedDevice();
+    const inputDriver = (device as any).inputDriver;
+    rs.spyOn(inputDriver, 'delay').mockResolvedValue(undefined);
+    mockState.libnut.moveMouse.mockClear();
+    mockState.libnut.mouseToggle.mockClear();
+
+    await device.inputPrimitives.pointer!.dragAndDrop(
+      { x: 100, y: 400 },
+      { x: 100, y: 100 },
+    );
+
+    const moves = mockState.libnut.moveMouse.mock.calls;
+    const moveOrders = mockState.libnut.moveMouse.mock.invocationCallOrder;
+    const [buttonDownOrder, buttonUpOrder] =
+      mockState.libnut.mouseToggle.mock.invocationCallOrder;
+
+    expect(moves).toHaveLength(21);
+    expect(moves[0]).toEqual([100, 400]);
+    expect(moves[1]).toEqual([100, 385]);
+    expect(moves.at(-1)).toEqual([100, 100]);
+    expect(moveOrders[0]).toBeLessThan(buttonDownOrder);
+    expect(moveOrders.slice(1).every((order) => order > buttonDownOrder)).toBe(
+      true,
+    );
+    expect(moveOrders.slice(1).every((order) => order < buttonUpOrder)).toBe(
+      true,
+    );
+  });
+
   it('does not trust a self-consistent libnut position outside screenshot space', async () => {
     const device = await createConnectedDeviceForPlatform('win32');
 


### PR DESCRIPTION
## Summary

- reproduce the Linux/VNC-style drag failure with a real Chromium window on Xvfb
- move the held pointer through intermediate coordinates so native drag state machines can observe the active drag before release
- add unit coverage for input ordering and a focused hosted-Linux regression job that needs no model credentials

## Root cause

The computer driver moved from source to target in one native pointer jump. Desktop drag-and-drop state machines use the first movement beyond their threshold to activate dragging, so the target needs a later held-button movement before mouseup. With only one jump, the source entered drag mode but the target never observed it.

## GitHub Actions reproduction

- Before (same stabilized fixture, legacy one-jump implementation): [failed](https://github.com/web-infra-dev/midscene/actions/runs/33834848669)
- After (20-step held-pointer trajectory): [passed](https://github.com/web-infra-dev/midscene/actions/runs/33834371461)

## Validation

- `pnpm run lint`
- `npx nx test @midscene/computer`
- `npx nx build @midscene/computer`
- `AI_TEST_TYPE=computer npx nx test @midscene/computer -- tests/ai/linux-drag-and-drop.test.ts --retry 0` (skipped locally on macOS; passed in the hosted Linux run above)