### PR TITLE
fix(studio): restrict file exports and default local services to loopback

### DIFF
--- a/apps/chrome-extension/src/extension/bridge/index.tsx
+++ b/apps/chrome-extension/src/extension/bridge/index.tsx
@@ -33,7 +33,7 @@ interface BridgeMessageRecord {
 }
 
 const BRIDGE_SERVER_URL_KEY = 'midscene-bridge-server-url';
-const DEFAULT_SERVER_URL = 'ws://localhost:3766';
+const DEFAULT_SERVER_URL = 'ws://127.0.0.1:3766';
 
 export default function Bridge() {
   const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>('closed');
@@ -403,7 +403,7 @@ export default function Bridge() {
                   <Input
                     value={serverUrl}
                     onChange={(e) => handleServerUrlChange(e.target.value)}
-                    placeholder="ws://localhost:3766"
+                    placeholder="ws://127.0.0.1:3766"
                     disabled={bridgeStatus !== 'closed'}
                     className="server-config-input"
                   />
@@ -411,7 +411,7 @@ export default function Bridge() {
                     {serverUrl && serverUrl !== DEFAULT_SERVER_URL ? (
                       <>Remote mode: Connect to {serverUrl}</>
                     ) : (
-                      <>Local mode (default): ws://localhost:3766</>
+                      <>Local mode (default): ws://127.0.0.1:3766</>
                     )}
                   </small>
                 </div>

--- a/apps/chrome-extension/src/extension/confirm/index.tsx
+++ b/apps/chrome-extension/src/extension/confirm/index.tsx
@@ -18,7 +18,7 @@ function ConfirmDialog() {
   useEffect(() => {
     // Get server URL from URL params
     const params = new URLSearchParams(window.location.search);
-    const url = params.get('serverUrl') || 'ws://localhost:3766';
+    const url = params.get('serverUrl') || 'ws://127.0.0.1:3766';
     setServerUrl(url);
 
     // Start countdown timer

--- a/apps/chrome-extension/src/scripts/worker.ts
+++ b/apps/chrome-extension/src/scripts/worker.ts
@@ -216,7 +216,7 @@ async function showConnectionConfirmDialog(
   }
 
   // Create confirm popup - centered on screen
-  const serverUrl = serverEndpoint || 'ws://localhost:3766';
+  const serverUrl = serverEndpoint || 'ws://127.0.0.1:3766';
   const popupWidth = 420;
   const popupHeight = 340;
 

--- a/apps/site/docs/en/platforms/android.mdx
+++ b/apps/site/docs/en/platforms/android.mdx
@@ -87,22 +87,6 @@ npx --yes @midscene/android-playground
 
 ![](/android-set-env.png)
 
-#### Remote screen preview
-
-Scrcpy screen streaming now listens on `127.0.0.1` by default. To open Android Playground from another computer, explicitly allow remote access to both the Playground server and its Scrcpy sidecar. For example, on macOS or Linux:
-
-```bash
-MIDSCENE_PLAYGROUND_HOST=0.0.0.0 MIDSCENE_SCRCPY_HOST=0.0.0.0 pnpm dlx @midscene/android-playground
-```
-
-Open the Playground using the server computer's reachable IP address or hostname and the Playground port printed at startup. Allow access to both the Playground and Scrcpy ports. `0.0.0.0` is a listening address, not the address to enter in the browser.
-
-`MIDSCENE_SCRCPY_HOST` applies to the standalone Android Playground CLI. It can also be set to a specific local interface address, such as `192.168.1.100`; the automatically opened local page uses that address for its screen preview. Code that creates `ScrcpyServer` directly can pass the `host` constructor option instead. Studio continues to use local-only screen streaming.
-
-:::warning
-Scrcpy does not yet authenticate preview sessions. Enabling remote access exposes device information and screen streams to clients that can reach the port. Only enable it on a trusted network with access restricted to intended clients.
-:::
-
 ## Use the JavaScript SDK
 
 Once Playground works, move to a repeatable script with the JavaScript SDK.
@@ -329,6 +313,22 @@ midscene-android tap \
 ```
 
 Each CLI command is a separate process, so pass the option to every command that should override the default. For the JavaScript SDK or YAML, set `scrcpyConfig.videoBitRate` once on that device configuration. Changing the bitrate trades encoded bandwidth against screenshot detail. Tune it only when independent transport measurements show a need, then validate screenshot and recognition quality. See the [`AndroidDevice` scrcpy reference](../reference/index.mdx#scrcpy) for the default and related options.
+
+### Remote screen preview
+
+Scrcpy screen streaming now listens on `127.0.0.1` by default. To open Android Playground from another computer, explicitly allow remote access to both the Playground server and its Scrcpy sidecar. For example, on macOS or Linux:
+
+```bash
+MIDSCENE_PLAYGROUND_HOST=0.0.0.0 MIDSCENE_SCRCPY_HOST=0.0.0.0 pnpm dlx @midscene/android-playground
+```
+
+Open the Playground using the server computer's reachable IP address or hostname and the Playground port printed at startup. Allow access to both the Playground and Scrcpy ports. `0.0.0.0` is a listening address, not the address to enter in the browser.
+
+`MIDSCENE_SCRCPY_HOST` applies to the standalone Android Playground CLI. It can also be set to a specific local interface address, such as `192.168.1.100`; the automatically opened local page uses that address for its screen preview. Code that creates `ScrcpyServer` directly can pass the `host` constructor option instead. Studio continues to use local-only screen streaming.
+
+:::warning
+Scrcpy does not yet authenticate preview sessions. Enabling remote access exposes device information and screen streams to clients that can reach the port. Only enable it on a trusted network with access restricted to intended clients.
+:::
 
 ### How do I use a custom adb path or remote adb server?
 

--- a/apps/site/docs/en/platforms/android.mdx
+++ b/apps/site/docs/en/platforms/android.mdx
@@ -87,6 +87,22 @@ npx --yes @midscene/android-playground
 
 ![](/android-set-env.png)
 
+#### Remote screen preview
+
+Scrcpy screen streaming now listens on `127.0.0.1` by default. To open Android Playground from another computer, explicitly allow remote access to both the Playground server and its Scrcpy sidecar. For example, on macOS or Linux:
+
+```bash
+MIDSCENE_PLAYGROUND_HOST=0.0.0.0 MIDSCENE_SCRCPY_HOST=0.0.0.0 pnpm dlx @midscene/android-playground
+```
+
+Open the Playground using the server computer's reachable IP address or hostname and the Playground port printed at startup. Allow access to both the Playground and Scrcpy ports. `0.0.0.0` is a listening address, not the address to enter in the browser.
+
+`MIDSCENE_SCRCPY_HOST` applies to the standalone Android Playground CLI. It can also be set to a specific local interface address, such as `192.168.1.100`; the automatically opened local page uses that address for its screen preview. Code that creates `ScrcpyServer` directly can pass the `host` constructor option instead. Studio continues to use local-only screen streaming.
+
+:::warning
+Scrcpy does not yet authenticate preview sessions. Enabling remote access exposes device information and screen streams to clients that can reach the port. Only enable it on a trusted network with access restricted to intended clients.
+:::
+
 ## Use the JavaScript SDK
 
 Once Playground works, move to a repeatable script with the JavaScript SDK.

--- a/apps/site/docs/zh/platforms/android.mdx
+++ b/apps/site/docs/zh/platforms/android.mdx
@@ -87,22 +87,6 @@ npx --yes @midscene/android-playground
 
 ![](/android-set-env.png)
 
-#### 远程投屏预览
-
-Scrcpy 投屏服务现在默认只监听 `127.0.0.1`。如果需要从另一台电脑访问 Android Playground，必须显式开启 Playground 服务和 Scrcpy 投屏服务的远程访问。例如，在 macOS 或 Linux 上运行：
-
-```bash
-MIDSCENE_PLAYGROUND_HOST=0.0.0.0 MIDSCENE_SCRCPY_HOST=0.0.0.0 pnpm dlx @midscene/android-playground
-```
-
-在浏览器中使用服务端电脑实际可访问的 IP 地址或主机名，以及启动时输出的 Playground 端口。需要同时允许访问 Playground 和 Scrcpy 的端口。`0.0.0.0` 是监听地址，不是浏览器中应填写的访问地址。
-
-`MIDSCENE_SCRCPY_HOST` 适用于独立的 Android Playground CLI，也可以设置为具体的本机网卡地址，例如 `192.168.1.100`；自动打开的本机页面会使用该地址连接投屏服务。直接创建 `ScrcpyServer` 的代码可以传入 `host` 构造参数。Studio 仍保持仅本机投屏。
-
-:::warning
-Scrcpy 尚未提供投屏会话认证。开启远程访问后，能够连接该端口的客户端可以获取设备信息和屏幕流。仅应在可信网络中开启，并限制为预期客户端可访问。
-:::
-
 ## 使用 JavaScript SDK
 
 当 Playground 运行正常后，就可以切换到可复用的 JavaScript 脚本。
@@ -332,6 +316,22 @@ midscene-android tap \
 ```
 
 每条 CLI 命令都是独立进程，因此每条需要覆盖默认码率的命令都要传入该参数。使用 JavaScript SDK 或 YAML 时，只需在对应设备配置中设置一次 `scrcpyConfig.videoBitRate`。调整码率是在编码带宽和截图细节之间取舍；只有独立的链路测量表明有需要时才应调优，并验证截图与识别质量。默认值和相关选项见 [`AndroidDevice` scrcpy 参考](../reference/index.mdx#scrcpy)。
+
+### 远程投屏预览
+
+Scrcpy 投屏服务现在默认只监听 `127.0.0.1`。如果需要从另一台电脑访问 Android Playground，必须显式开启 Playground 服务和 Scrcpy 投屏服务的远程访问。例如，在 macOS 或 Linux 上运行：
+
+```bash
+MIDSCENE_PLAYGROUND_HOST=0.0.0.0 MIDSCENE_SCRCPY_HOST=0.0.0.0 pnpm dlx @midscene/android-playground
+```
+
+在浏览器中使用服务端电脑实际可访问的 IP 地址或主机名，以及启动时输出的 Playground 端口。需要同时允许访问 Playground 和 Scrcpy 的端口。`0.0.0.0` 是监听地址，不是浏览器中应填写的访问地址。
+
+`MIDSCENE_SCRCPY_HOST` 适用于独立的 Android Playground CLI，也可以设置为具体的本机网卡地址，例如 `192.168.1.100`；自动打开的本机页面会使用该地址连接投屏服务。直接创建 `ScrcpyServer` 的代码可以传入 `host` 构造参数。Studio 仍保持仅本机投屏。
+
+:::warning
+Scrcpy 尚未提供投屏会话认证。开启远程访问后，能够连接该端口的客户端可以获取设备信息和屏幕流。仅应在可信网络中开启，并限制为预期客户端可访问。
+:::
 
 ### 如何使用自定义的 adb 路径或远程 adb 服务器？
 

--- a/apps/site/docs/zh/platforms/android.mdx
+++ b/apps/site/docs/zh/platforms/android.mdx
@@ -87,6 +87,22 @@ npx --yes @midscene/android-playground
 
 ![](/android-set-env.png)
 
+#### 远程投屏预览
+
+Scrcpy 投屏服务现在默认只监听 `127.0.0.1`。如果需要从另一台电脑访问 Android Playground，必须显式开启 Playground 服务和 Scrcpy 投屏服务的远程访问。例如，在 macOS 或 Linux 上运行：
+
+```bash
+MIDSCENE_PLAYGROUND_HOST=0.0.0.0 MIDSCENE_SCRCPY_HOST=0.0.0.0 pnpm dlx @midscene/android-playground
+```
+
+在浏览器中使用服务端电脑实际可访问的 IP 地址或主机名，以及启动时输出的 Playground 端口。需要同时允许访问 Playground 和 Scrcpy 的端口。`0.0.0.0` 是监听地址，不是浏览器中应填写的访问地址。
+
+`MIDSCENE_SCRCPY_HOST` 适用于独立的 Android Playground CLI，也可以设置为具体的本机网卡地址，例如 `192.168.1.100`；自动打开的本机页面会使用该地址连接投屏服务。直接创建 `ScrcpyServer` 的代码可以传入 `host` 构造参数。Studio 仍保持仅本机投屏。
+
+:::warning
+Scrcpy 尚未提供投屏会话认证。开启远程访问后，能够连接该端口的客户端可以获取设备信息和屏幕流。仅应在可信网络中开启，并限制为预期客户端可访问。
+:::
+
 ## 使用 JavaScript SDK
 
 当 Playground 运行正常后，就可以切换到可复用的 JavaScript 脚本。

--- a/apps/studio/src/main/file-export.ts
+++ b/apps/studio/src/main/file-export.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, realpath, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  BrowserWindow,
+  IpcMain,
+  IpcMainInvokeEvent,
+  WebContents,
+  dialog as electronDialog,
+} from 'electron';
+import {
+  type ChooseFileSavePathRequest,
+  IPC_CHANNELS,
+  type WriteFileRequest,
+  type WriteReportFileRequest,
+} from '../shared/electron-contract';
+
+type ExportKind = 'report' | 'file';
+type ExportState = {
+  generation: number;
+  grants: Map<string, { kind: ExportKind; parent: string }>;
+};
+
+/** Only native save dialogs can grant a single write to an exact destination. */
+export function registerFileExportHandlers(options: {
+  ipcMain: Pick<IpcMain, 'handle'>;
+  dialog: Pick<typeof electronDialog, 'showSaveDialog'>;
+  getWindow: () => BrowserWindow | null;
+  getDownloadsPath: () => string;
+  isTrustedUrl: (url: string) => boolean;
+}) {
+  const states = new WeakMap<WebContents, ExportState>();
+
+  const getSender = (event: IpcMainInvokeEvent) => {
+    const window = options.getWindow();
+    if (
+      !window ||
+      window.isDestroyed() ||
+      event.sender !== window.webContents ||
+      !event.senderFrame ||
+      event.senderFrame !== window.webContents.mainFrame ||
+      !options.isTrustedUrl(event.senderFrame.url)
+    ) {
+      throw new Error('File export is only available to the Studio main page');
+    }
+    const existing = states.get(event.sender);
+    if (existing) return { window, state: existing };
+    const state: ExportState = { generation: 0, grants: new Map() };
+    states.set(event.sender, state);
+    const invalidate = () => {
+      state.generation += 1;
+      state.grants.clear();
+    };
+    event.sender.on('did-start-navigation', (details) => {
+      if (details.isMainFrame && !details.isSameDocument) invalidate();
+    });
+    event.sender.on('render-process-gone', invalidate);
+    event.sender.on('destroyed', invalidate);
+    return { window, state };
+  };
+
+  const choose = async (
+    event: IpcMainInvokeEvent,
+    kind: ExportKind,
+    request?: ChooseFileSavePathRequest,
+  ) => {
+    const { window, state } = getSender(event);
+    const generation = state.generation;
+    const defaultName =
+      kind === 'report' ? 'midscene_report.html' : 'midscene_export.json';
+    const filters =
+      kind === 'report'
+        ? [{ name: 'HTML Report', extensions: ['html'] }]
+        : request?.filters?.length
+          ? request.filters
+          : [{ name: 'All Files', extensions: ['*'] }];
+    // Extensions influence the final destination, so never allow path segments.
+    for (const filter of filters) {
+      if (
+        !Array.isArray(filter.extensions) ||
+        filter.extensions.some(
+          (extension) =>
+            typeof extension !== 'string' ||
+            !/^(?:\*|[a-z0-9]+)$/i.test(extension),
+        )
+      )
+        throw new Error('Invalid file export extension');
+    }
+    let defaultFileName = path.basename(
+      request?.defaultFileName?.trim() || defaultName,
+    );
+    if (kind === 'report' && !defaultFileName.toLowerCase().endsWith('.html')) {
+      defaultFileName += '.html';
+    }
+    const result = await options.dialog.showSaveDialog(window, {
+      title:
+        kind === 'report'
+          ? 'Save Midscene Report'
+          : request?.title || 'Save Midscene Export',
+      defaultPath: path.join(options.getDownloadsPath(), defaultFileName),
+      filters,
+    });
+    if (result.canceled || !result.filePath) return null;
+    getSender(event);
+    if (state.generation !== generation)
+      throw new Error('Studio page changed during file export');
+    // Use precisely what the native dialog approved; never append a path suffix
+    // after confirmation (which could bypass its overwrite confirmation).
+    const target = result.filePath;
+    if (!path.isAbsolute(target))
+      throw new Error('Save destination must be absolute');
+    const parent = await realpath(path.dirname(target));
+    if (state.generation !== generation)
+      throw new Error('Studio page changed during file export');
+    state.grants.set(target, { kind, parent });
+    return target;
+  };
+
+  const save = async (
+    event: IpcMainInvokeEvent,
+    kind: ExportKind,
+    request: WriteFileRequest | WriteReportFileRequest,
+  ) => {
+    const { state } = getSender(event);
+    if (
+      typeof request?.path !== 'string' ||
+      typeof request?.content !== 'string'
+    ) {
+      throw new Error('File export requires a path and string content');
+    }
+    const encoding = 'encoding' in request ? request.encoding : undefined;
+    if (encoding && encoding !== 'utf-8' && encoding !== 'base64') {
+      throw new Error('Unsupported file export encoding');
+    }
+    const grant = state.grants.get(request.path);
+    if (!grant || grant.kind !== kind)
+      throw new Error('Choose a save destination before writing this file');
+    // Consume before the first await, including failed writes and concurrent calls.
+    state.grants.delete(request.path);
+    const parent = await realpath(path.dirname(request.path));
+    if (parent !== grant.parent)
+      throw new Error('Save destination changed; choose it again');
+    const target = path.join(parent, path.basename(request.path));
+    const temporaryDirectory = await mkdtemp(
+      path.join(parent, '.midscene-export-'),
+    );
+    try {
+      const temporaryFile = path.join(temporaryDirectory, 'export');
+      await writeFile(
+        temporaryFile,
+        encoding === 'base64'
+          ? Buffer.from(request.content, 'base64')
+          : request.content,
+        { mode: 0o600 },
+      );
+      // Replacing the directory entry avoids following a destination symlink
+      // or modifying another file through a hard link.
+      await rename(temporaryFile, target);
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  };
+
+  options.ipcMain.handle(
+    IPC_CHANNELS.chooseReportSavePath,
+    (event, defaultFileName?: string) =>
+      choose(event, 'report', { defaultFileName }),
+  );
+  options.ipcMain.handle(
+    IPC_CHANNELS.chooseFileSavePath,
+    (event, request?: ChooseFileSavePathRequest) =>
+      choose(event, 'file', request),
+  );
+  options.ipcMain.handle(
+    IPC_CHANNELS.writeReportFile,
+    (event, request: WriteReportFileRequest) => save(event, 'report', request),
+  );
+  options.ipcMain.handle(
+    IPC_CHANNELS.writeFile,
+    (event, request: WriteFileRequest) => save(event, 'file', request),
+  );
+}

--- a/apps/studio/src/main/index.ts
+++ b/apps/studio/src/main/index.ts
@@ -11,14 +11,11 @@ import path from 'node:path';
 import { setMidsceneRunDir } from '@midscene/shared/common';
 import { setLogDirectoryResolver } from '@midscene/shared/logger';
 import {
-  type ChooseFileSavePathRequest,
   type ChooseReplayFileResult,
   type DiscoverDevicesRequest,
   IPC_CHANNELS,
   type OpenImagePreviewRequest,
   type PrepareRecorderMarkdownReplayRequest,
-  type WriteFileRequest,
-  type WriteReportFileRequest,
 } from '@shared/electron-contract';
 import type { NativeThemeMode } from '@shared/electron-contract';
 import { resolveExternalUrl } from '@shared/external-links';
@@ -37,6 +34,7 @@ import {
 import type { TitleBarOverlay } from 'electron';
 import { normalizeStudioAgentOptions } from '../shared/agent-options';
 import { MACOS_TRAFFIC_LIGHT_POSITION } from '../shared/titlebar-layout';
+import { registerFileExportHandlers } from './file-export';
 import { startStudioEventLoopWatchdog } from './performance-watchdog';
 import { requestPlaygroundBootstrap } from './playground/bootstrap-request';
 import { runConnectivityTest } from './playground/connectivity-test';
@@ -63,6 +61,10 @@ import {
   type WindowRevealController,
   registerWindowRevealHandlers,
 } from './window-reveal';
+import {
+  isStudioRendererUrl,
+  restrictStudioNavigation,
+} from './window-security';
 
 const shouldBootstrapStudio = acquireStudioSingleInstanceLock(app);
 
@@ -210,44 +212,6 @@ const getTitleBarOverlay = (): TitleBarOverlay => ({
   height: 56,
   symbolColor: '#17212b',
 });
-
-const DEFAULT_REPORT_FILE_NAME = 'midscene_report.html';
-const DEFAULT_EXPORT_FILE_NAME = 'midscene_export.json';
-
-const ensureHtmlFileName = (value: string) =>
-  value.toLowerCase().endsWith('.html') ? value : `${value}.html`;
-
-const resolveDefaultReportSavePath = (defaultFileName?: string) => {
-  const safeFileName = path.basename(
-    ensureHtmlFileName(defaultFileName?.trim() || DEFAULT_REPORT_FILE_NAME),
-  );
-  return path.join(app.getPath('downloads'), safeFileName);
-};
-
-const resolveDefaultFileSavePath = (defaultFileName?: string) => {
-  const safeFileName = path.basename(
-    defaultFileName?.trim() || DEFAULT_EXPORT_FILE_NAME,
-  );
-  return path.join(app.getPath('downloads'), safeFileName);
-};
-
-const ensureFileExtensionFromFilters = (
-  filePath: string,
-  filters?: ChooseFileSavePathRequest['filters'],
-) => {
-  if (path.extname(filePath)) {
-    return filePath;
-  }
-  const firstExtension = filters?.find((filter) => filter.extensions.length)
-    ?.extensions[0];
-  if (!firstExtension) {
-    return filePath;
-  }
-  if (firstExtension === '*') {
-    return filePath;
-  }
-  return `${filePath}.${firstExtension.replace(/^\./, '')}`;
-};
 
 const sanitizeImagePreviewFileName = (fileName?: string) => {
   const baseName = path.basename(fileName?.trim() || 'screenshot.png');
@@ -422,10 +386,13 @@ const createMainWindow = () => {
       contextIsolation: true,
       nodeIntegration: false,
       preload: preloadEntryPath,
-      sandbox: false,
+      sandbox: true,
     },
   });
 
+  restrictStudioNavigation(window.webContents, (url) =>
+    isStudioRendererUrl(url, rendererEntryPath, rendererDevUrl),
+  );
   mainWindow = window;
 
   const revealController = registerWindowRevealHandlers({
@@ -442,10 +409,26 @@ const createMainWindow = () => {
   if (isStudioSmokeTest || isStudioE2ETest) {
     window.webContents.once('did-finish-load', () => {
       if (isStudioSmokeTest) {
-        console.log(STUDIO_SMOKE_READY_MARKER);
-        setTimeout(() => {
-          app.exit(0);
-        }, 100);
+        // The page can load even when a sandboxed preload fails. Exercise the
+        // native bridge before declaring the startup smoke test successful.
+        void window.webContents
+          .executeJavaScript(`
+          (async () => {
+            if (typeof window.electronShell?.writeFile !== 'function' ||
+                typeof window.electronShell?.chooseReportSavePath !== 'function') {
+              throw new Error('Studio file export bridge is unavailable');
+            }
+            return window.studioUpdater.getVersion();
+          })()
+        `)
+          .then(() => {
+            console.log(STUDIO_SMOKE_READY_MARKER);
+            app.exit(0);
+          })
+          .catch((error) => {
+            console.error(STUDIO_SMOKE_FAILED_MARKER, error);
+            app.exit(1);
+          });
         return;
       }
 
@@ -547,6 +530,18 @@ const activateMainWindow = (): BrowserWindow | null => {
 };
 
 const registerIpcHandlers = () => {
+  registerFileExportHandlers({
+    ipcMain,
+    dialog,
+    getWindow: () => mainWindow,
+    getDownloadsPath: () => app.getPath('downloads'),
+    isTrustedUrl: (url) =>
+      isStudioRendererUrl(
+        url,
+        getRendererEntryPath(),
+        process.env.MIDSCENE_STUDIO_RENDERER_URL,
+      ),
+  });
   ipcMain.handle(IPC_CHANNELS.minimizeWindow, () => {
     mainWindow?.minimize();
   });
@@ -581,53 +576,6 @@ const registerIpcHandlers = () => {
       if (errorMessage) {
         throw new Error(errorMessage);
       }
-    },
-  );
-  ipcMain.handle(
-    IPC_CHANNELS.chooseReportSavePath,
-    async (_event, defaultFileName?: string) => {
-      const dialogOptions = {
-        title: 'Save Midscene Report',
-        defaultPath: resolveDefaultReportSavePath(defaultFileName),
-        filters: [
-          {
-            name: 'HTML Report',
-            extensions: ['html'],
-          },
-        ],
-      };
-      const result = mainWindow
-        ? await dialog.showSaveDialog(mainWindow, dialogOptions)
-        : await dialog.showSaveDialog(dialogOptions);
-
-      if (result.canceled || !result.filePath) {
-        return null;
-      }
-
-      return ensureHtmlFileName(result.filePath);
-    },
-  );
-  ipcMain.handle(
-    IPC_CHANNELS.chooseFileSavePath,
-    async (_event, request?: ChooseFileSavePathRequest) => {
-      const filters =
-        request?.filters && request.filters.length > 0
-          ? request.filters
-          : [{ name: 'All Files', extensions: ['*'] }];
-      const dialogOptions = {
-        title: request?.title || 'Save Midscene Export',
-        defaultPath: resolveDefaultFileSavePath(request?.defaultFileName),
-        filters,
-      };
-      const result = mainWindow
-        ? await dialog.showSaveDialog(mainWindow, dialogOptions)
-        : await dialog.showSaveDialog(dialogOptions);
-
-      if (result.canceled || !result.filePath) {
-        return null;
-      }
-
-      return ensureFileExtensionFromFilters(result.filePath, filters);
     },
   );
   ipcMain.handle(
@@ -730,47 +678,6 @@ const registerIpcHandlers = () => {
       if (process.platform === 'darwin') {
         mainWindow.setVibrancy('sidebar');
       }
-    },
-  );
-  ipcMain.handle(
-    IPC_CHANNELS.writeReportFile,
-    async (_event, request: WriteReportFileRequest) => {
-      const targetPath = request?.path?.trim();
-      if (!targetPath) {
-        throw new Error('writeReportFile: path is required');
-      }
-      if (typeof request.content !== 'string') {
-        throw new Error('writeReportFile: content must be a string');
-      }
-
-      await writeFileToDisk(
-        ensureHtmlFileName(targetPath),
-        request.content,
-        'utf-8',
-      );
-    },
-  );
-  ipcMain.handle(
-    IPC_CHANNELS.writeFile,
-    async (_event, request: WriteFileRequest) => {
-      const targetPath = request?.path?.trim();
-      if (!targetPath) {
-        throw new Error('writeFile: path is required');
-      }
-      if (typeof request.content !== 'string') {
-        throw new Error('writeFile: content must be a string');
-      }
-      if (request.encoding === 'base64') {
-        await writeFileToDisk(
-          targetPath,
-          Buffer.from(request.content, 'base64'),
-        );
-        return;
-      }
-      if (request.encoding && request.encoding !== 'utf-8') {
-        throw new Error(`writeFile: unsupported encoding ${request.encoding}`);
-      }
-      await writeFileToDisk(targetPath, request.content, 'utf-8');
     },
   );
   // Multi-platform playground — a single server for Android, iOS,

--- a/apps/studio/src/main/window-security.ts
+++ b/apps/studio/src/main/window-security.ts
@@ -1,0 +1,33 @@
+import { pathToFileURL } from 'node:url';
+import type { WebContents } from 'electron';
+
+export function isStudioRendererUrl(
+  url: string,
+  entryPath: string,
+  devUrl?: string,
+) {
+  try {
+    const candidate = new URL(url);
+    const expected = new URL(devUrl || pathToFileURL(entryPath).href);
+    // Hash routing is local to the same document. Other documents, even at
+    // the same dev-server origin, must not inherit the native bridge.
+    candidate.hash = '';
+    expected.hash = '';
+    return candidate.href === expected.href;
+  } catch {
+    return false;
+  }
+}
+
+export function restrictStudioNavigation(
+  contents: WebContents,
+  isTrustedUrl: (url: string) => boolean,
+) {
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }));
+  contents.on('will-navigate', (event) => {
+    if (!isTrustedUrl(event.url)) event.preventDefault();
+  });
+  contents.on('will-redirect', (event) => {
+    if (!isTrustedUrl(event.url)) event.preventDefault();
+  });
+}

--- a/apps/studio/src/shared/electron-contract.ts
+++ b/apps/studio/src/shared/electron-contract.ts
@@ -240,9 +240,9 @@ export interface ElectronShellApi {
   openRunDirectory: () => Promise<void>;
   /** Open an image with the operating system's default image viewer. */
   openImagePreview: (request: OpenImagePreviewRequest) => Promise<void>;
-  /** Ask the main process for a target path for a report HTML export. */
+  /** Authorize one report write through a native save dialog. Reload revokes it. */
   chooseReportSavePath: (defaultFileName?: string) => Promise<string | null>;
-  /** Ask the main process for a target path for a generic file export. */
+  /** Authorize one generic file write through a native save dialog. */
   chooseFileSavePath: (
     request?: ChooseFileSavePathRequest,
   ) => Promise<string | null>;
@@ -251,9 +251,9 @@ export interface ElectronShellApi {
    * window is not available (e.g. during teardown).
    */
   toggleMaximizeWindow: () => Promise<void>;
-  /** Persist a report HTML file using the native shell process. */
+  /** Write once to the exact path returned by chooseReportSavePath. */
   writeReportFile: (request: WriteReportFileRequest) => Promise<void>;
-  /** Persist a generic text or base64-encoded binary file via the shell. */
+  /** Write text or base64 once to the exact path returned by chooseFileSavePath. */
   writeFile: (request: WriteFileRequest) => Promise<void>;
   /**
    * Sync the app's resolved theme to the OS so window chrome (border,

--- a/apps/studio/tests/file-export.test.ts
+++ b/apps/studio/tests/file-export.test.ts
@@ -1,0 +1,264 @@
+import { EventEmitter } from 'node:events';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { IpcMainInvokeEvent } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerFileExportHandlers } from '../src/main/file-export';
+import { IPC_CHANNELS } from '../src/shared/electron-contract';
+
+let directory: string;
+function setup() {
+  const handlers = new Map<string, (...args: any[]) => any>();
+  const frame = { url: 'file:///studio/index.html' };
+  const contents = Object.assign(new EventEmitter(), { mainFrame: frame });
+  const window = { webContents: contents, isDestroyed: () => false };
+  const dialog = { showSaveDialog: vi.fn() };
+  registerFileExportHandlers({
+    ipcMain: {
+      handle: (channel, handler) => {
+        handlers.set(channel, handler);
+      },
+    },
+    dialog,
+    getWindow: () => window as any,
+    getDownloadsPath: () => directory,
+    isTrustedUrl: (url) => url === 'file:///studio/index.html',
+  });
+  const event = {
+    sender: contents,
+    senderFrame: frame,
+  } as unknown as IpcMainInvokeEvent;
+  const invoke = (
+    channel: keyof typeof IPC_CHANNELS,
+    arg?: unknown,
+    sender = event,
+  ) => handlers.get(IPC_CHANNELS[channel])!(sender, arg);
+  return { invoke, dialog, contents, event };
+}
+
+beforeEach(async () => {
+  directory = await mkdtemp(path.join(os.tmpdir(), 'studio-export-test-'));
+});
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe('native file export authorization', () => {
+  it('rejects arbitrary writes, cancellation, and changes to the approved path', async () => {
+    const { invoke, dialog } = setup();
+    const selected = path.join(directory, 'selected.txt');
+    const other = path.join(directory, 'other.txt');
+    await writeFile(other, 'unchanged');
+    await expect(
+      invoke('writeFile', { path: other, content: 'attack' }),
+    ).rejects.toThrow('Choose a save');
+    dialog.showSaveDialog.mockResolvedValue({ canceled: true });
+    expect(await invoke('chooseFileSavePath')).toBeNull();
+    await expect(
+      invoke('writeFile', { path: selected, content: 'attack' }),
+    ).rejects.toThrow('Choose a save');
+    dialog.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: selected,
+    });
+    expect(await invoke('chooseFileSavePath')).toBe(selected);
+    await expect(
+      invoke('writeFile', { path: other, content: 'attack' }),
+    ).rejects.toThrow('Choose a save');
+    expect(await readFile(other, 'utf-8')).toBe('unchanged');
+  });
+
+  it.each(['file', 'report'] as const)(
+    'writes an approved %s only once, including concurrent requests',
+    async (kind) => {
+      const { invoke, dialog } = setup();
+      const selected = path.join(
+        directory,
+        kind === 'report' ? 'report.html' : 'export.zip',
+      );
+      dialog.showSaveDialog.mockResolvedValue({
+        canceled: false,
+        filePath: selected,
+      });
+      await invoke(
+        kind === 'report' ? 'chooseReportSavePath' : 'chooseFileSavePath',
+      );
+      const request =
+        kind === 'report'
+          ? { path: selected, content: '<html>report</html>' }
+          : {
+              path: selected,
+              content: Buffer.from('binary data').toString('base64'),
+              encoding: 'base64',
+            };
+      const channel = kind === 'report' ? 'writeReportFile' : 'writeFile';
+      const first = invoke(channel, request);
+      await expect(invoke(channel, request)).rejects.toThrow('Choose a save');
+      await first;
+      expect(await readFile(selected, 'utf-8')).toBe(
+        kind === 'report' ? request.content : 'binary data',
+      );
+    },
+  );
+
+  it('does not share approval between the report and generic write channels', async () => {
+    const { invoke, dialog } = setup();
+    const selected = path.join(directory, 'report.html');
+    dialog.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: selected,
+    });
+    await invoke('chooseReportSavePath');
+    await expect(
+      invoke('writeFile', { path: selected, content: 'attack' }),
+    ).rejects.toThrow('Choose a save');
+  });
+
+  it('rejects other windows and subframes', async () => {
+    const { invoke, event } = setup();
+    await expect(
+      invoke('chooseFileSavePath', undefined, {
+        ...event,
+        senderFrame: { url: 'file:///studio/index.html' },
+      } as any),
+    ).rejects.toThrow('main page');
+    await expect(
+      invoke('writeFile', { path: '/tmp/attack', content: 'attack' }, {
+        ...event,
+        sender: {},
+      } as any),
+    ).rejects.toThrow('main page');
+  });
+
+  it('invalidates approval on reload and rejects a dialog completed after navigation', async () => {
+    const { invoke, dialog, contents } = setup();
+    const selected = path.join(directory, 'export.txt');
+    dialog.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: selected,
+    });
+    await invoke('chooseFileSavePath');
+    contents.emit('did-start-navigation', {
+      isMainFrame: true,
+      isSameDocument: false,
+    });
+    await expect(
+      invoke('writeFile', { path: selected, content: 'attack' }),
+    ).rejects.toThrow('Choose a save');
+    let finish!: (result: any) => void;
+    dialog.showSaveDialog.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const choice = invoke('chooseFileSavePath');
+    contents.emit('did-start-navigation', {
+      isMainFrame: true,
+      isSameDocument: false,
+    });
+    finish({ canceled: false, filePath: selected });
+    await expect(choice).rejects.toThrow('page changed');
+  });
+
+  it('replaces an approved symlink without overwriting its target', async () => {
+    const { invoke, dialog } = setup();
+    const selected = path.join(directory, 'selected.txt');
+    const other = path.join(directory, 'private.txt');
+    await writeFile(other, 'private');
+    await symlink(other, selected);
+    dialog.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: selected,
+    });
+    await invoke('chooseFileSavePath');
+    await invoke('writeFile', { path: selected, content: 'exported' });
+    expect(await readFile(other, 'utf-8')).toBe('private');
+    expect(await readFile(selected, 'utf-8')).toBe('exported');
+  });
+
+  it('rejects path segments in renderer-supplied extensions', async () => {
+    const { invoke, dialog } = setup();
+    await expect(
+      invoke('chooseFileSavePath', {
+        filters: [{ name: 'bad', extensions: ['../../other'] }],
+      }),
+    ).rejects.toThrow('extension');
+    expect(dialog.showSaveDialog).not.toHaveBeenCalled();
+  });
+  it('rejects an untrusted document even in the original main frame', async () => {
+    const { invoke, event } = setup();
+    Object.assign(event.senderFrame!, { url: 'https://evil.test' });
+    await expect(invoke('chooseFileSavePath')).rejects.toThrow('main page');
+  });
+
+  it('rejects a parent symlink redirected after approval', async () => {
+    const { invoke, dialog } = setup();
+    const original = path.join(directory, 'original');
+    const other = path.join(directory, 'other');
+    const alias = path.join(directory, 'alias');
+    await mkdir(original);
+    await mkdir(other);
+    await symlink(original, alias);
+    const selected = path.join(alias, 'export.txt');
+    await writeFile(path.join(other, 'export.txt'), 'unchanged');
+    dialog.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: selected,
+    });
+    await invoke('chooseFileSavePath');
+    await unlink(alias);
+    await symlink(other, alias);
+    await expect(
+      invoke('writeFile', { path: selected, content: 'attack' }),
+    ).rejects.toThrow('destination changed');
+    expect(await readFile(path.join(other, 'export.txt'), 'utf-8')).toBe(
+      'unchanged',
+    );
+  });
+
+  it('uses the exact approved filename and requires a new dialog after a failed write', async () => {
+    const { invoke, dialog } = setup();
+    const selected = path.join(directory, 'report-without-suffix');
+    await writeFile(selected, 'old report');
+    dialog.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: selected,
+    });
+    expect(await invoke('chooseReportSavePath')).toBe(selected);
+    await expect(
+      invoke('writeReportFile', {
+        path: `${selected}.html`,
+        content: 'attack',
+      }),
+    ).rejects.toThrow('Choose a save');
+    await invoke('writeReportFile', { path: selected, content: 'new report' });
+    expect(await readFile(selected, 'utf-8')).toBe('new report');
+
+    const folder = path.join(directory, 'folder');
+    await mkdir(folder);
+    dialog.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: folder,
+    });
+    await invoke('chooseFileSavePath');
+    await expect(
+      invoke('writeFile', {
+        path: folder,
+        content: 'cannot replace directory',
+      }),
+    ).rejects.toThrow();
+    await expect(
+      invoke('writeFile', { path: folder, content: 'retry' }),
+    ).rejects.toThrow('Choose a save');
+  });
+});

--- a/apps/studio/tests/window-security.test.ts
+++ b/apps/studio/tests/window-security.test.ts
@@ -1,0 +1,59 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isStudioRendererUrl,
+  restrictStudioNavigation,
+} from '../src/main/window-security';
+
+describe('Studio navigation restrictions', () => {
+  it('only trusts the exact renderer document, allowing hash routing', () => {
+    expect(
+      isStudioRendererUrl(
+        'file:///studio/index.html#settings',
+        '/studio/index.html',
+      ),
+    ).toBe(true);
+    for (const url of [
+      'https://evil.test',
+      'file:///studio/other.html',
+      'file:///studio/index.html?other',
+    ]) {
+      expect(isStudioRendererUrl(url, '/studio/index.html')).toBe(false);
+    }
+    expect(
+      isStudioRendererUrl(
+        'http://127.0.0.1:5173/#settings',
+        '/studio/index.html',
+        'http://127.0.0.1:5173',
+      ),
+    ).toBe(true);
+    expect(
+      isStudioRendererUrl(
+        'http://127.0.0.1:5173/other',
+        '/studio/index.html',
+        'http://127.0.0.1:5173',
+      ),
+    ).toBe(false);
+  });
+  it('blocks new windows, untrusted navigation and redirects', () => {
+    const contents = Object.assign(new EventEmitter(), {
+      setWindowOpenHandler: vi.fn(),
+    });
+    restrictStudioNavigation(
+      contents as any,
+      (url) => url === 'file:///studio/index.html',
+    );
+    expect(contents.setWindowOpenHandler.mock.calls[0][0]()).toEqual({
+      action: 'deny',
+    });
+    for (const name of ['will-navigate', 'will-redirect']) {
+      const event = { preventDefault: vi.fn(), url: 'https://evil.test' };
+      contents.emit(name, event);
+      expect(event.preventDefault).toHaveBeenCalledOnce();
+      event.preventDefault.mockClear();
+      event.url = 'file:///studio/index.html';
+      contents.emit(name, event);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/android-playground/src/bin.ts
+++ b/packages/android-playground/src/bin.ts
@@ -9,7 +9,9 @@ const main = async () => {
   const { default: open } = await import('open');
 
   try {
-    const scrcpyServer = new ScrcpyServer();
+    const scrcpyServer = new ScrcpyServer({
+      host: process.env.MIDSCENE_SCRCPY_HOST,
+    });
     const prepared = await androidPlaygroundPlatform.prepare({
       staticDir,
       scrcpyServer,

--- a/packages/android-playground/src/platform.ts
+++ b/packages/android-playground/src/platform.ts
@@ -17,6 +17,8 @@ import {
 } from '@midscene/shared/constants';
 import { findAvailablePort } from '@midscene/shared/node';
 export interface ScrcpyServerController {
+  /** Bind host, used to connect local Playground pages to this sidecar. */
+  readonly host?: string;
   currentDeviceId: string | null;
   launch(port?: number): Promise<unknown>;
   close(): unknown;
@@ -76,6 +78,11 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
         : findAvailablePort(SCRCPY_SERVER_PORT),
     ]);
     const scrcpyPort = resolvedScrcpyPort;
+    const scrcpyHost = options?.scrcpyServer?.host;
+    const scrcpyPreviewOptions = {
+      scrcpyPort,
+      ...(scrcpyHost ? { scrcpyHost } : {}),
+    };
 
     if (playgroundPort !== PLAYGROUND_SERVER_PORT) {
       console.log(
@@ -151,10 +158,9 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
         return {
           agent,
           agentFactory: connectAgent,
-          preview: createScrcpyPreviewDescriptor(
-            { scrcpyPort },
-            { title: 'Android device preview' },
-          ),
+          preview: createScrcpyPreviewDescriptor(scrcpyPreviewOptions, {
+            title: 'Android device preview',
+          }),
           displayName: deviceId,
           metadata: {
             deviceId,
@@ -190,14 +196,9 @@ export const androidPlaygroundPlatform = definePlaygroundPlatform<
           server.scrcpyPort = scrcpyPort;
         },
       },
-      preview: createScrcpyPreviewDescriptor(
-        {
-          scrcpyPort,
-        },
-        {
-          title: 'Android device preview',
-        },
-      ),
+      preview: createScrcpyPreviewDescriptor(scrcpyPreviewOptions, {
+        title: 'Android device preview',
+      }),
       metadata: {
         scrcpyPort,
         sessionConnected: false,

--- a/packages/android-playground/src/scrcpy-server.ts
+++ b/packages/android-playground/src/scrcpy-server.ts
@@ -93,6 +93,8 @@ export interface ScrcpyDeviceListSource {
 }
 
 export interface ScrcpyServerOptions {
+  /** Defaults to loopback. Set explicitly to expose previews remotely. */
+  host?: string;
   deviceListSource?: ScrcpyDeviceListSource;
 }
 
@@ -114,11 +116,14 @@ export default class ScrcpyServer {
   adbClient: AdbServerClient | null = null;
   currentDeviceId: string | null = null;
   devicePollInterval: NodeJS.Timeout | null = null;
+  readonly host: string;
   private deviceListSource?: ScrcpyDeviceListSource;
   private deviceListSourceUnsubscribe?: () => void;
   lastDeviceList = ''; // use for comparing changes
 
   constructor(options: ScrcpyServerOptions = {}) {
+    this.host = options.host ?? '127.0.0.1';
+    if (!this.host.trim()) throw new Error('Scrcpy host must not be empty');
     this.deviceListSource = options.deviceListSource;
     this.app = express();
     this.httpServer = createServer(this.app);
@@ -854,11 +859,18 @@ export default class ScrcpyServer {
 
   // launch server
   async launch(port?: number) {
-    this.port = port || this.defaultPort;
-    return new Promise<this>((resolve) => {
+    this.port = port ?? this.defaultPort;
+    return new Promise<this>((resolve, reject) => {
       const listenPort = this.port ?? this.defaultPort;
-      this.httpServer.listen(listenPort, '0.0.0.0', () => {
-        console.log(`Scrcpy server running at: http://0.0.0.0:${this.port}`);
+      const onError = (error: Error) => reject(error);
+      this.httpServer.once('error', onError);
+      this.httpServer.listen(listenPort, this.host, () => {
+        this.httpServer.off('error', onError);
+        const address = this.httpServer.address();
+        if (address && typeof address !== 'string') this.port = address.port;
+        console.log(
+          `Scrcpy server running at: http://${this.host}:${this.port}`,
+        );
         // start device monitoring
         this.startDeviceMonitoring();
         resolve(this);

--- a/packages/android-playground/tests/unit/platform-session-manager.test.ts
+++ b/packages/android-playground/tests/unit/platform-session-manager.test.ts
@@ -77,6 +77,27 @@ describe('androidPlaygroundPlatform session manager', () => {
     expect(connectMock).toHaveBeenCalled();
   });
 
+  test.each(['127.0.0.1', '192.168.1.100', '0.0.0.0', '::1'])(
+    'includes the Scrcpy bind host %s before and after device connection',
+    async (host) => {
+      const { androidPlaygroundPlatform } = await import('../../src/platform');
+      const scrcpyServer = {
+        host,
+        currentDeviceId: null,
+        launch: rs.fn(async () => {}),
+        close: rs.fn(),
+      };
+      const prepared = await androidPlaygroundPlatform.prepare({
+        scrcpyServer,
+      });
+      expect(prepared.preview?.custom).toMatchObject({ scrcpyHost: host });
+      const session = await prepared.sessionManager!.createSession({
+        deviceId: 'SERIAL123',
+      });
+      expect(session.preview?.custom).toMatchObject({ scrcpyHost: host });
+    },
+  );
+
   test('keeps the setup schema usable when adb discovery fails', async () => {
     getConnectedDevicesWithDetailsMock
       .mockRejectedValueOnce(new Error('adb executable not found'))

--- a/packages/android-playground/tests/unit/scrcpy-server.test.ts
+++ b/packages/android-playground/tests/unit/scrcpy-server.test.ts
@@ -169,3 +169,51 @@ describe('ScrcpyServer', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Scrcpy listen address', () => {
+  it.each([undefined, '0.0.0.0'])(
+    'binds to the default loopback or explicit host %s',
+    async (host) => {
+      const server = new ScrcpyServer({
+        host,
+        deviceListSource: {
+          getDevices: async () => [],
+          subscribe: () => () => {},
+        },
+      });
+      try {
+        await server.launch(0);
+        expect((server.httpServer.address() as any).address).toBe(
+          host ?? '127.0.0.1',
+        );
+        const response = await fetch(
+          `http://127.0.0.1:${server.port}/api/devices`,
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+          devices: [],
+          currentDeviceId: null,
+        });
+      } finally {
+        server.close();
+      }
+    },
+  );
+  it('rejects an occupied port instead of hanging', async () => {
+    const options = {
+      deviceListSource: {
+        getDevices: async () => [],
+        subscribe: () => () => {},
+      },
+    };
+    const first = new ScrcpyServer(options);
+    const second = new ScrcpyServer(options);
+    try {
+      await first.launch(0);
+      await expect(second.launch(first.port!)).rejects.toThrow();
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
+});

--- a/packages/playground-app/src/runtime-info.ts
+++ b/packages/playground-app/src/runtime-info.ts
@@ -120,6 +120,8 @@ export function resolvePreviewConnectionInfo(
       resolvedScrcpyPort && resolvedServerUrl
         ? (() => {
             const url = new URL(resolvedServerUrl);
+            // Match the sidecar's IPv4 loopback default without DNS ambiguity.
+            if (url.hostname === 'localhost') url.hostname = '127.0.0.1';
             url.port = String(resolvedScrcpyPort);
             url.pathname = '/';
             url.search = '';

--- a/packages/playground-app/src/runtime-info.ts
+++ b/packages/playground-app/src/runtime-info.ts
@@ -120,8 +120,29 @@ export function resolvePreviewConnectionInfo(
       resolvedScrcpyPort && resolvedServerUrl
         ? (() => {
             const url = new URL(resolvedServerUrl);
-            // Match the sidecar's IPv4 loopback default without DNS ambiguity.
-            if (url.hostname === 'localhost') url.hostname = '127.0.0.1';
+            // The CLI opens a local page even when the sidecar binds to a
+            // specific LAN interface. Use that bind host for local pages;
+            // remote pages keep their reachable hostname (e.g. behind NAT).
+            if (['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)) {
+              const bindHost =
+                typeof preview.custom?.scrcpyHost === 'string'
+                  ? preview.custom.scrcpyHost.trim()
+                  : '';
+              if (bindHost && bindHost !== '0.0.0.0' && bindHost !== '::') {
+                url.hostname =
+                  bindHost.includes(':') && !bindHost.startsWith('[')
+                    ? `[${bindHost}]`
+                    : bindHost;
+              } else if (bindHost === '::') {
+                url.hostname = '[::1]';
+              } else if (
+                bindHost === '0.0.0.0' ||
+                url.hostname === 'localhost'
+              ) {
+                // A wildcard is a listen address, never a connection address.
+                url.hostname = '127.0.0.1';
+              }
+            }
             url.port = String(resolvedScrcpyPort);
             url.pathname = '/';
             url.search = '';

--- a/packages/playground-app/tests/runtime-info.test.ts
+++ b/packages/playground-app/tests/runtime-info.test.ts
@@ -90,7 +90,7 @@ describe('playground app runtime info helpers', () => {
       deviceId: 'SERIAL123',
       type: 'scrcpy',
       scrcpyPort: 6501,
-      scrcpyUrl: 'http://localhost:6501/',
+      scrcpyUrl: 'http://127.0.0.1:6501/',
     });
   });
 

--- a/packages/playground-app/tests/runtime-info.test.ts
+++ b/packages/playground-app/tests/runtime-info.test.ts
@@ -116,6 +116,41 @@ describe('playground app runtime info helpers', () => {
     });
   });
 
+  test.each([
+    ['192.168.1.100', 'http://localhost:5800', 'http://192.168.1.100:7700/'],
+    ['192.168.1.100', 'http://127.0.0.1:5800', 'http://192.168.1.100:7700/'],
+    ['127.0.0.1', 'http://localhost:5800', 'http://127.0.0.1:7700/'],
+    ['0.0.0.0', 'http://localhost:5800', 'http://127.0.0.1:7700/'],
+    ['0.0.0.0', 'http://192.168.1.100:5800', 'http://192.168.1.100:7700/'],
+    ['::1', 'http://localhost:5800', 'http://[::1]:7700/'],
+    ['::', 'http://localhost:5800', 'http://[::1]:7700/'],
+    ['2001:db8::1', 'http://localhost:5800', 'http://[2001:db8::1]:7700/'],
+    [
+      '192.168.1.100',
+      'https://midscene.example.com:5800',
+      'https://midscene.example.com:7700/',
+    ],
+  ])(
+    'resolves Scrcpy host %s from runtime URL %s',
+    (scrcpyHost, serverUrl, expected) => {
+      expect(
+        resolvePreviewConnectionInfo(
+          {
+            interface: { type: 'android' },
+            preview: {
+              kind: 'scrcpy',
+              capabilities: [],
+              custom: { scrcpyPort: 7700, scrcpyHost },
+            },
+            executionUxHints: [],
+            metadata: {},
+          },
+          serverUrl,
+        ).scrcpyUrl,
+      ).toBe(expected);
+    },
+  );
+
   test('falls back to screenshot polling for remote android devices', () => {
     expect(
       resolvePreviewConnectionInfo(

--- a/packages/web-integration/src/bridge-mode/io-server.ts
+++ b/packages/web-integration/src/bridge-mode/io-server.ts
@@ -17,6 +17,7 @@ import {
   BridgeErrorCodeNoClientConnected,
   BridgeEvent,
   BridgeSignalKill,
+  DefaultBridgeServerHost,
   DefaultBridgeServerPort,
 } from './common';
 
@@ -39,7 +40,10 @@ function isTrustedOrigin(origin: string | undefined): boolean {
   return false;
 }
 
-export const killRunningServer = async (port?: number, host = 'localhost') => {
+export const killRunningServer = async (
+  port?: number,
+  host = DefaultBridgeServerHost,
+) => {
   try {
     const client = ClientIO(`ws://${host}:${port || DefaultBridgeServerPort}`, {
       query: {
@@ -126,14 +130,8 @@ export class BridgeServer {
         reject(new Error(`Bridge Listening Error: ${err.message}`));
       });
 
-      // Start listening BEFORE creating Socket.IO Server
-      // When host is 127.0.0.1 (default), don't specify host to listen on all local interfaces (IPv4 + IPv6)
-      // This ensures localhost resolves correctly in both IPv4 and IPv6 environments
-      if (this.host === '127.0.0.1') {
-        httpServer.listen(this.port);
-      } else {
-        httpServer.listen(this.port, this.host);
-      }
+      // Always honor the configured interface, including the loopback default.
+      httpServer.listen(this.port, this.host);
 
       // Now create Socket.IO Server attached to the already-listening HTTP server
       this.io = new Server(httpServer, {

--- a/packages/web-integration/src/bridge-mode/page-browser-side.ts
+++ b/packages/web-integration/src/bridge-mode/page-browser-side.ts
@@ -8,6 +8,7 @@ import type {
 import {
   type BridgeConnectTabOptions,
   BridgeEvent,
+  DefaultBridgeServerHost,
   DefaultBridgeServerPort,
   KeyboardEvent,
   MouseEvent,
@@ -101,7 +102,8 @@ export class ExtensionBridgePageBrowserSide extends ChromeExtensionProxyPage {
 
   private async setupBridgeClient() {
     const endpoint =
-      this.serverEndpoint || `ws://localhost:${DefaultBridgeServerPort}`;
+      this.serverEndpoint ||
+      `ws://${DefaultBridgeServerHost}:${DefaultBridgeServerPort}`;
 
     // Create confirmation gate BEFORE establishing connection,
     // so that any calls received immediately after connection are blocked

--- a/packages/web-integration/tests/unit-test/bridge/io.test.ts
+++ b/packages/web-integration/tests/unit-test/bridge/io.test.ts
@@ -25,7 +25,7 @@ describe('bridge-io', () => {
     const server = new BridgeServer(DEFAULT_HOST, port);
     await server.listen();
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.resolve('ok');
       },
@@ -37,7 +37,7 @@ describe('bridge-io', () => {
 
     const onDisconnect = rs.fn();
     const client2 = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.resolve('ok');
       },
@@ -93,7 +93,7 @@ describe('bridge-io', () => {
     await server.listen();
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.resolve('ok');
       },
@@ -113,7 +113,7 @@ describe('bridge-io', () => {
     const server = new BridgeServer(DEFAULT_HOST, port);
     await server.listen();
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         expect(method).toBe(method);
         expect(args).toEqual(args);
@@ -136,7 +136,7 @@ describe('bridge-io', () => {
     await server.listen();
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.reject(new Error(errMsg));
       },
@@ -155,7 +155,7 @@ describe('bridge-io', () => {
     const fn = rs.fn();
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.resolve('ok');
       },
@@ -183,7 +183,7 @@ describe('bridge-io', () => {
     );
     await server.listen();
 
-    const client = new BridgeClient(`ws://localhost:${port}`, () => {
+    const client = new BridgeClient(`ws://127.0.0.1:${port}`, () => {
       return Promise.resolve('ok');
     });
     await client.connect();
@@ -203,7 +203,7 @@ describe('bridge-io', () => {
     await server.listen();
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.resolve('ok');
       },
@@ -230,7 +230,7 @@ describe('bridge-io', () => {
     await server.listen();
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         throw new Error('internal error');
       },
@@ -249,7 +249,7 @@ describe('bridge-io', () => {
     await server.listen();
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return new Promise((resolve, reject) => {
           setTimeout(() => {
@@ -283,7 +283,7 @@ describe('bridge-io', () => {
     let resolveConfirmation!: (allowed: boolean) => void;
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       async (method, args) => {
         // Same check as page-browser-side.ts
         if (confirmationPromise) {
@@ -344,7 +344,7 @@ describe('bridge-io', () => {
     });
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       async (method, args) => {
         // Block on confirmation before processing, just like page-browser-side.ts
         const allowed = await confirmationPromise;
@@ -394,7 +394,7 @@ describe('bridge-io', () => {
     });
 
     const client = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       async (method, args) => {
         const allowed = await confirmationPromise;
         if (!allowed) {
@@ -427,7 +427,7 @@ describe('bridge-io', () => {
     server1.listen();
 
     const client = new BridgeClient(
-      `ws://localhost:${commonPort}`,
+      `ws://127.0.0.1:${commonPort}`,
       (method, args) => {
         return Promise.resolve('ok');
       },
@@ -443,7 +443,7 @@ describe('bridge-io', () => {
     server2.listen();
 
     const client2 = new BridgeClient(
-      `ws://localhost:${commonPort}`,
+      `ws://127.0.0.1:${commonPort}`,
       (method, args) => {
         return Promise.resolve('ok2');
       },
@@ -461,7 +461,7 @@ describe('bridge-io', () => {
     await server.listen();
 
     const client1 = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.resolve('response1');
       },
@@ -477,7 +477,7 @@ describe('bridge-io', () => {
 
     // Extension clicks Start → new client connects to the SAME server
     const client2 = new BridgeClient(
-      `ws://localhost:${port}`,
+      `ws://127.0.0.1:${port}`,
       (method, args) => {
         return Promise.resolve('response2');
       },

--- a/packages/web-integration/tests/unit-test/bridge/security.test.ts
+++ b/packages/web-integration/tests/unit-test/bridge/security.test.ts
@@ -6,7 +6,7 @@
  * 2. Cross-origin kill signals are rejected (DoS prevention)
  *
  * Protection mechanism: Socket.IO middleware checks the Origin header on
- * every connection. Only trusted origins (no Origin = local process, or
+ * every connection. Only trusted origins (no Origin = native client, or
  * chrome-extension://) are allowed. Browser pages cannot forge or omit
  * the Origin header on WebSocket handshakes.
  *
@@ -40,7 +40,7 @@ function tryConnect(
   } = {},
 ): Promise<{ connected: boolean; gotConnectedEvent: boolean }> {
   return new Promise((resolve) => {
-    const client = ClientIO(`ws://localhost:${port}`, {
+    const client = ClientIO(`ws://127.0.0.1:${port}`, {
       extraHeaders: opts.origin ? { Origin: opts.origin } : undefined,
       query: { version: 'test', ...(opts.query || {}) },
       transports: ['websocket'],
@@ -115,7 +115,7 @@ describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
     await server.listen();
 
     // Malicious client tries to connect first to hijack the session
-    const maliciousClient = ClientIO(`ws://localhost:${port}`, {
+    const maliciousClient = ClientIO(`ws://127.0.0.1:${port}`, {
       extraHeaders: { Origin: 'https://attacker.com' },
       query: { version: 'evil' },
       transports: ['websocket'],
@@ -158,8 +158,8 @@ describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
     const server = new BridgeServer(DEFAULT_HOST, port);
     await server.listen();
 
-    // Connect a legitimate client first (no Origin = local process)
-    const legitClient = ClientIO(`ws://localhost:${port}`, {
+    // Connect a legitimate client first (no Origin = native client)
+    const legitClient = ClientIO(`ws://127.0.0.1:${port}`, {
       query: { version: 'legit' },
       transports: ['websocket'],
       reconnection: false,
@@ -179,7 +179,7 @@ describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
     });
 
     // Simulate malicious webpage sending kill signal
-    const maliciousClient = ClientIO(`ws://localhost:${port}`, {
+    const maliciousClient = ClientIO(`ws://127.0.0.1:${port}`, {
       extraHeaders: { Origin: 'https://evil.com' },
       query: { [BridgeSignalKill]: '1' },
       transports: ['websocket'],
@@ -212,8 +212,8 @@ describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
     const server = new BridgeServer(DEFAULT_HOST, port);
     await server.listen();
 
-    // Connect a legitimate client (no Origin = local process)
-    const client = ClientIO(`ws://localhost:${port}`, {
+    // Connect a legitimate client (no Origin = native client)
+    const client = ClientIO(`ws://127.0.0.1:${port}`, {
       query: { version: 'test' },
       transports: ['websocket'],
       reconnection: false,
@@ -240,7 +240,7 @@ describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
     await server.listen();
 
     let receivedMethod = '';
-    const client = ClientIO(`ws://localhost:${port}`, {
+    const client = ClientIO(`ws://127.0.0.1:${port}`, {
       query: { version: 'test' },
       transports: ['websocket'],
       reconnection: false,
@@ -295,7 +295,7 @@ describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
     await server1.listen({ timeout: false });
 
     // Connect a client to server1 so we can verify it's alive
-    const client1 = ClientIO(`ws://localhost:${port}`, {
+    const client1 = ClientIO(`ws://127.0.0.1:${port}`, {
       query: { version: 'test' },
       transports: ['websocket'],
       reconnection: false,
@@ -337,4 +337,20 @@ describe('Bridge Server Security (GHSA-mrhp-4xj5-p96f)', () => {
     client1.close();
     await server2.close();
   }, 15000);
+});
+
+describe('Bridge listen address', () => {
+  it.each(['127.0.0.1', '0.0.0.0'])(
+    'honors configured host %s',
+    async (host) => {
+      const server = new BridgeServer(host, nextPort());
+      try {
+        await server.listen({ timeout: false });
+        expect((server as any).io.httpServer.address().address).toBe(host);
+        expect((await tryConnect(server.port)).connected).toBe(true);
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Studio previously accepted renderer-supplied file paths without requiring approval from a native save dialog. Bridge and Scrcpy could also listen on external interfaces by default.

## Changes

- Require a native save dialog before Studio writes to an exact destination. Authorization is single-use, restricted to the trusted main page, and revoked on navigation or reload.
- Write exports atomically without following destination symlinks.
- Enable Studio’s renderer sandbox and block untrusted navigation, redirects, and new windows.
- Make Bridge honor its configured host and use IPv4 loopback consistently for default client connections.
- Default Scrcpy to loopback, retain explicit remote configuration, and document it in English and Chinese.

## Scope
- Addresses Studio’s arbitrary-path export writes and default network exposure.
- Bridge and Scrcpy session authentication remains outside this change. Explicit remote access still requires a trusted, restricted network.
- Physical-device and Windows/Linux regression testing remains outstanding.

## Validation

```sh
pnpm run lint
pnpm exec nx test studio -- tests/file-export.test.ts tests/window-security.test.ts tests/report-download.test.ts tests/studio-recorder-export.test.ts
pnpm exec nx test studio -- tests/android-runtime.test.ts tests/electron-contract.test.ts tests/rsbuild-config.test.ts tests/scrcpy-sidecar-process.test.ts
pnpm exec nx test @midscene/web -- tests/unit-test/bridge/ tests/unit-test/bridge-tab-connection.test.ts
pnpm exec nx test @midscene/android-playground
pnpm exec nx test @midscene/playground-app -- tests/runtime-info.test.ts
pnpm exec nx test chrome-extension -- tests/bridge-start-stop.test.ts
pnpm exec nx run-many --target=build --projects=@midscene/web,@midscene/android-playground,@midscene/playground-app,studio,chrome-extension
env -u NO_COLOR MIDSCENE_STUDIO_RUN_STARTUP_SMOKE=1 pnpm exec nx test studio -- tests/startup-smoke.test.mjs
```

All checks passed. The Electron startup smoke test ran outside the execution sandbox and verified that preload IPC remains available with the renderer sandbox enabled.

@codex