### PR TITLE
ci(workflow): add `notify_stable_release` dispatch option to toggle IM notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: 'Release Branch(confirm release branch)'
         required: true
         default: 'main'
+      notify_stable_release:
+        description: 'Send IM notifications for a stable release'
+        required: true
+        type: boolean
+        default: true
 
 # Add permissions for creating releases.
 # `id-token: write` is required for npm Trusted Publishers (OIDC) and for
@@ -475,7 +480,7 @@ jobs:
     needs:
     - release
     - package_studio
-    if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
+    if: ${{ inputs.notify_stable_release && needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
@@ -659,7 +664,7 @@ jobs:
     needs:
     - release
     - package_studio
-    if: ${{ needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
+    if: ${{ inputs.notify_stable_release && needs.release.result == 'success' && needs.package_studio.result == 'success' && needs.release.outputs.is_prerelease != 'true' }}
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read


### PR DESCRIPTION
### Motivation

- Make sending IM notifications for stable releases configurable so maintainers can opt out of Discord/Feishu announcements when they don’t want them. 
- Default behaviour remains to send notifications (safe default `true`) while allowing the workflow invoker to disable them.

### Description

- Add a new workflow dispatch input `notify_stable_release` (boolean, default `true`) to `/.github/workflows/release.yml` so callers can opt out of IM notifications. 
- Gate the `notify_discord` job with `if: ${{ inputs.notify_stable_release && ... }}` so it only runs for stable releases when the option is enabled. 
- Apply the same `inputs.notify_stable_release` guard to the `notify_feishu` job to skip Feishu notifications when disabled.

### Testing

- Ran `git diff --check` which reported no issues. 
- Ran `pnpm exec biome check .github/workflows/release.yml --diagnostic-level=info --no-errors-on-unmatched` to validate the modified workflow file and it passed. 
- Attempted `pnpm run lint` but it was blocked by repository-local `.pnpm-store` files that exceed Biome size limits and include third-party lint findings, so only the workflow-specific checks were completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9e60e36f9083248d6758ab67d89027)