### PR TITLE
feat(core): add GPT-6 adapter and model-specific Codex parameters

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -226,11 +226,12 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="gemini"
 
 | Model version | Commonly used model names | `MIDSCENE_MODEL_FAMILY` | Notes |
 | --- | --- | --- | --- |
+| GPT-6 series | `gpt-6-astra` | `gpt-6` | |
 | GPT-5 series | `gpt-5.4`, `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | `gpt-5` | Models before GPT-5.4 do not support visual localization and can only be used as Planning or Insight models. In practical localization tests, GPT-5.5 and GPT-5.6 perform noticeably better than GPT-5.4; we recommend using GPT-5.5 or GPT-5.6 first. |
 
 </div>
 
-Environment variable configuration example, using `gpt-5.5`:
+Environment variable configuration example, using `gpt-6-astra`:
 
 <ModelConfigTabs>
   <ModelConfigTab type="default">
@@ -238,8 +239,8 @@ Environment variable configuration example, using `gpt-5.5`:
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://api.openai.com/v1" # OpenAI API endpoint; or your compatible endpoint
 MIDSCENE_MODEL_API_KEY="sk-..."
-MIDSCENE_MODEL_NAME="gpt-5.5"
-MIDSCENE_MODEL_FAMILY="gpt-5"
+MIDSCENE_MODEL_NAME="gpt-6-astra"
+MIDSCENE_MODEL_FAMILY="gpt-6"
 ```
 
   </ModelConfigTab>
@@ -248,8 +249,8 @@ MIDSCENE_MODEL_FAMILY="gpt-5"
 ```bash
 MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.openai.com/v1" # OpenAI API endpoint; or your compatible endpoint
 MIDSCENE_PLANNING_MODEL_API_KEY="sk-..."
-MIDSCENE_PLANNING_MODEL_NAME="gpt-5.5"
-MIDSCENE_PLANNING_MODEL_FAMILY="gpt-5"
+MIDSCENE_PLANNING_MODEL_NAME="gpt-6-astra"
+MIDSCENE_PLANNING_MODEL_FAMILY="gpt-6"
 ```
 
   </ModelConfigTab>
@@ -258,12 +259,24 @@ MIDSCENE_PLANNING_MODEL_FAMILY="gpt-5"
 ```bash
 MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.openai.com/v1" # OpenAI API endpoint; or your compatible endpoint
 MIDSCENE_INSIGHT_MODEL_API_KEY="sk-..."
-MIDSCENE_INSIGHT_MODEL_NAME="gpt-5.5"
-MIDSCENE_INSIGHT_MODEL_FAMILY="gpt-5"
+MIDSCENE_INSIGHT_MODEL_NAME="gpt-6-astra"
+MIDSCENE_INSIGHT_MODEL_FAMILY="gpt-6"
 ```
 
   </ModelConfigTab>
 </ModelConfigTabs>
+
+**Fast mode**
+
+Both GPT-5.6 Sol and GPT-6 Astra support Fast mode. Add the `service_tier` request body parameter to enable it. For example, with GPT-5.6 Sol:
+
+```bash
+MIDSCENE_MODEL_NAME="gpt-5.6-sol"
+MIDSCENE_MODEL_FAMILY="gpt-5"
+MIDSCENE_MODEL_EXTRA_BODY_JSON='{"service_tier":"fast"}'
+```
+
+According to OpenAI, Fast mode can deliver up to 2–2.5× the speed at twice the Standard rate. Refer to the [official documentation](https://developers.openai.com/api/docs/guides/fast-mode) for current speed, pricing, and usage restrictions.
 
 <span id="use-codex-app-server-oauth-no-api-key" />
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -226,11 +226,12 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="gemini"
 
 | 模型版本 | 常用模型名称 | `MIDSCENE_MODEL_FAMILY` | 备注 |
 | --- | --- | --- | --- |
+| GPT-6 系列 | `gpt-6-astra` | `gpt-6` | |
 | GPT-5 系列 | `gpt-5.4`、`gpt-5.5`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna` | `gpt-5` | GPT-5.4 之前的模型不支持视觉定位，仅可用作 Planning 模型或 Insight 模型。在实际定位测试中，GPT-5.5 和 GPT-5.6 的定位效果明显优于 GPT-5.4，建议优先使用 GPT-5.5 或 GPT-5.6。 |
 
 </div>
 
-环境变量配置示例，以 `gpt-5.5` 为例：
+环境变量配置示例，以 `gpt-6-astra` 为例：
 
 <ModelConfigTabs>
   <ModelConfigTab type="default">
@@ -238,8 +239,8 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="gemini"
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://api.openai.com/v1" # OpenAI API 地址；或你的兼容服务地址
 MIDSCENE_MODEL_API_KEY="sk-..."
-MIDSCENE_MODEL_NAME="gpt-5.5"
-MIDSCENE_MODEL_FAMILY="gpt-5"
+MIDSCENE_MODEL_NAME="gpt-6-astra"
+MIDSCENE_MODEL_FAMILY="gpt-6"
 ```
 
   </ModelConfigTab>
@@ -248,8 +249,8 @@ MIDSCENE_MODEL_FAMILY="gpt-5"
 ```bash
 MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.openai.com/v1" # OpenAI API 地址；或你的兼容服务地址
 MIDSCENE_PLANNING_MODEL_API_KEY="sk-..."
-MIDSCENE_PLANNING_MODEL_NAME="gpt-5.5"
-MIDSCENE_PLANNING_MODEL_FAMILY="gpt-5"
+MIDSCENE_PLANNING_MODEL_NAME="gpt-6-astra"
+MIDSCENE_PLANNING_MODEL_FAMILY="gpt-6"
 ```
 
   </ModelConfigTab>
@@ -258,12 +259,24 @@ MIDSCENE_PLANNING_MODEL_FAMILY="gpt-5"
 ```bash
 MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.openai.com/v1" # OpenAI API 地址；或你的兼容服务地址
 MIDSCENE_INSIGHT_MODEL_API_KEY="sk-..."
-MIDSCENE_INSIGHT_MODEL_NAME="gpt-5.5"
-MIDSCENE_INSIGHT_MODEL_FAMILY="gpt-5"
+MIDSCENE_INSIGHT_MODEL_NAME="gpt-6-astra"
+MIDSCENE_INSIGHT_MODEL_FAMILY="gpt-6"
 ```
 
   </ModelConfigTab>
 </ModelConfigTabs>
+
+**Fast mode**
+
+GPT-5.6 Sol 和 GPT-6 Astra 均支持 Fast mode，可以追加 `service_tier` 请求体参数启用，以 GPT-5.6 Sol 为例：
+
+```bash
+MIDSCENE_MODEL_NAME="gpt-5.6-sol"
+MIDSCENE_MODEL_FAMILY="gpt-5"
+MIDSCENE_MODEL_EXTRA_BODY_JSON='{"service_tier":"fast"}'
+```
+
+按照 OpenAI 官方说明，Fast mode 可获得最高 2～2.5 倍的速度，费率为 Standard 费率的两倍。具体速度、价格和使用限制以[官方说明](https://developers.openai.com/api/docs/guides/fast-mode)为准。
 
 <span id="use-codex-app-server-oauth-no-api-key" />
 

--- a/packages/core/src/ai-model/model-adapter/codex-app-server.ts
+++ b/packages/core/src/ai-model/model-adapter/codex-app-server.ts
@@ -1,0 +1,23 @@
+import type {
+  CodexAppServerCallInput,
+  CodexAppServerParamsResult,
+} from './types';
+
+export const buildDefaultCodexAppServerParams = ({
+  userConfig = {},
+}: CodexAppServerCallInput): CodexAppServerParamsResult => {
+  if (userConfig.reasoningEnabled !== true) {
+    return { config: { effort: 'none' } };
+  }
+
+  const effort = userConfig.reasoningEffort?.trim().toLowerCase();
+  return {
+    config: {
+      effort:
+        effort &&
+        ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'].includes(effort)
+          ? effort
+          : 'medium',
+    },
+  };
+};

--- a/packages/core/src/ai-model/model-adapter/resolve.ts
+++ b/packages/core/src/ai-model/model-adapter/resolve.ts
@@ -1,10 +1,12 @@
 import { parseModelResponseJson } from '../shared/json';
 import { resolveChatCompletion } from './chat-completion';
+import { buildDefaultCodexAppServerParams } from './codex-app-server';
 import { resolveInsight } from './insight';
 import type { InsightAdapter } from './insight-protocol';
 import { resolveLocate } from './locate';
 import { resolveCustomPlanningDefinition, resolvePlanning } from './planning';
 import type {
+  BuildCodexAppServerParams,
   ChatCompletionAdapter,
   ImagePreprocessPolicy,
   JsonParser,
@@ -39,6 +41,7 @@ function resolveImagePreprocess(
 export class ResolvedModelAdapter implements ModelAdapter {
   readonly jsonParser: JsonParser;
   readonly chatCompletion: ChatCompletionAdapter;
+  readonly buildCodexAppServerParams: BuildCodexAppServerParams;
   readonly acceptBbox2dAlias: boolean;
   readonly imagePreprocess: ImagePreprocessPolicy;
   readonly insight: InsightAdapter;
@@ -48,6 +51,8 @@ export class ResolvedModelAdapter implements ModelAdapter {
   constructor(config: ModelAdapterDefinition, modelFamily: string) {
     this.jsonParser = resolveJsonParser(config.jsonParser);
     this.chatCompletion = resolveChatCompletion(config.chatCompletion);
+    this.buildCodexAppServerParams =
+      config.buildCodexAppServerParams ?? buildDefaultCodexAppServerParams;
     this.acceptBbox2dAlias = config.acceptBbox2dAlias ?? false;
     this.imagePreprocess = resolveImagePreprocess(config.imagePreprocess);
     this.insight = resolveInsight(config.insight, {

--- a/packages/core/src/ai-model/model-adapter/types.ts
+++ b/packages/core/src/ai-model/model-adapter/types.ts
@@ -93,6 +93,24 @@ export interface ChatCompletionCallContext {
 
 export type ImageDetail = 'auto' | 'low' | 'high' | 'original';
 
+export interface CodexAppServerCallInput {
+  intent?: TIntent;
+  requiresOriginalImageDetail?: boolean;
+  userConfig?: ReasoningInput;
+}
+
+export interface CodexAppServerParamsResult {
+  config: {
+    effort?: string;
+  };
+  /** Applied to image input items rather than turn/start parameters. */
+  imageDetail?: ImageDetail;
+}
+
+export type BuildCodexAppServerParams = (
+  input: CodexAppServerCallInput,
+) => CodexAppServerParamsResult;
+
 export interface ContentAndReasoning {
   content: string;
   reasoning_content: string;
@@ -261,6 +279,7 @@ export type LocateDefinition =
 export interface ModelAdapter {
   jsonParser: JsonParser;
   chatCompletion: ChatCompletionAdapter;
+  buildCodexAppServerParams: BuildCodexAppServerParams;
   acceptBbox2dAlias: boolean;
   imagePreprocess: ImagePreprocessPolicy;
   insight: InsightAdapter;
@@ -288,6 +307,7 @@ export interface ModelRuntime {
 export interface ModelAdapterDefinition {
   jsonParser?: JsonParserPreset | JsonParser;
   chatCompletion?: ChatCompletionDefinition;
+  buildCodexAppServerParams?: BuildCodexAppServerParams;
   /**
    * Temporary compatibility for models that may occasionally return
    * `bbox_2d` instead of `bbox`. Currently enabled only by Qwen adapters and

--- a/packages/core/src/ai-model/models/gpt.ts
+++ b/packages/core/src/ai-model/models/gpt.ts
@@ -46,6 +46,26 @@ const buildGpt5ChatCompletionParams = (
   };
 };
 
+const buildGpt6ChatCompletionParams = (
+  input: ChatCompletionCallContext,
+): ChatCompletionParamsResult => {
+  const { userConfig, expectedJsonObjectResponse } = input;
+  const { reasoningEnabled, reasoningEffort, responseFormat } = userConfig;
+
+  // Astra cannot disable reasoning; use its lowest effort when disabled.
+  const effectiveReasoningEffort =
+    reasoningEnabled === false ? 'low' : (reasoningEffort ?? 'low');
+
+  const config: Record<string, unknown> = {
+    reasoning_effort: effectiveReasoningEffort,
+  };
+  if (responseFormat !== 'none' && expectedJsonObjectResponse) {
+    config.response_format = { type: 'json_object' };
+  }
+
+  return { config };
+};
+
 export const gptAdapters = {
   'gpt-5': {
     chatCompletion: {
@@ -61,4 +81,21 @@ export const gptAdapters = {
       },
     },
   },
-} satisfies Pick<Record<TModelFamily, ModelAdapterDefinition>, 'gpt-5'>;
+  'gpt-6': {
+    chatCompletion: {
+      unsupportedUserConfig: ['temperature', 'reasoningBudget'],
+      buildChatCompletionParams: buildGpt6ChatCompletionParams,
+      resolveImageDetail: originalImageDetailForDefaultIntent,
+    },
+    locate: {
+      element: {
+        resultFormat: {
+          coordinates: { shape: 'bbox', order: 'xy' },
+        },
+      },
+    },
+  },
+} satisfies Pick<
+  Record<TModelFamily, ModelAdapterDefinition>,
+  'gpt-5' | 'gpt-6'
+>;

--- a/packages/core/src/ai-model/models/gpt.ts
+++ b/packages/core/src/ai-model/models/gpt.ts
@@ -2,23 +2,59 @@ import type { TModelFamily } from '@midscene/shared/env';
 import type {
   ChatCompletionCallContext,
   ChatCompletionParamsResult,
+  CodexAppServerCallInput,
+  CodexAppServerParamsResult,
   ImageDetail,
   ModelAdapterDefinition,
+  ReasoningInput,
 } from '../model-adapter/types';
 import { isLocateIntent } from './utils/intent';
 
 const originalImageDetailForDefaultIntent = (
-  input: ChatCompletionCallContext,
+  input: Pick<
+    CodexAppServerCallInput,
+    'intent' | 'requiresOriginalImageDetail'
+  >,
 ): ImageDetail | undefined =>
   isLocateIntent(input.intent) || input.requiresOriginalImageDetail
     ? 'original'
     : undefined;
 
+const resolveGpt5ReasoningEffort = ({
+  reasoningEnabled,
+  reasoningEffort,
+}: ReasoningInput): string | undefined => {
+  if (reasoningEnabled === 'default') return undefined;
+  return reasoningEnabled === true ? (reasoningEffort ?? 'medium') : 'none';
+};
+
+// Astra cannot disable reasoning; use its lowest effort when disabled.
+const resolveGpt6ReasoningEffort = ({
+  reasoningEnabled,
+  reasoningEffort,
+}: ReasoningInput): string | undefined => {
+  if (reasoningEnabled === 'default') return undefined;
+  return reasoningEnabled === true ? (reasoningEffort ?? 'medium') : 'low';
+};
+
+const buildGpt5CodexAppServerParams = (
+  input: CodexAppServerCallInput,
+): CodexAppServerParamsResult => ({
+  config: { effort: resolveGpt5ReasoningEffort(input.userConfig ?? {}) },
+  imageDetail: originalImageDetailForDefaultIntent(input),
+});
+
+const buildGpt6CodexAppServerParams = (
+  input: CodexAppServerCallInput,
+): CodexAppServerParamsResult => ({
+  config: { effort: resolveGpt6ReasoningEffort(input.userConfig ?? {}) },
+  imageDetail: originalImageDetailForDefaultIntent(input),
+});
+
 const buildGpt5ChatCompletionParams = (
   input: ChatCompletionCallContext,
 ): ChatCompletionParamsResult => {
   const { midsceneDefaults, userConfig } = input;
-  const { reasoningEnabled, reasoningEffort } = userConfig;
   const commonOverrideConfig: Record<string, unknown> = {};
 
   if (userConfig.temperature !== undefined) {
@@ -34,8 +70,7 @@ const buildGpt5ChatCompletionParams = (
     commonOverrideConfig.response_format = { type: 'json_object' };
   }
 
-  const effectiveReasoningEffort =
-    reasoningEnabled === true ? (reasoningEffort ?? 'medium') : 'none';
+  const effectiveReasoningEffort = resolveGpt5ReasoningEffort(userConfig);
 
   return {
     config: {
@@ -49,25 +84,29 @@ const buildGpt5ChatCompletionParams = (
 const buildGpt6ChatCompletionParams = (
   input: ChatCompletionCallContext,
 ): ChatCompletionParamsResult => {
-  const { userConfig, expectedJsonObjectResponse } = input;
-  const { reasoningEnabled, reasoningEffort, responseFormat } = userConfig;
-
-  // Astra cannot disable reasoning; use its lowest effort when disabled.
-  const effectiveReasoningEffort =
-    reasoningEnabled === false ? 'low' : (reasoningEffort ?? 'low');
-
-  const config: Record<string, unknown> = {
-    reasoning_effort: effectiveReasoningEffort,
-  };
+  const { midsceneDefaults, userConfig, expectedJsonObjectResponse } = input;
+  const { responseFormat } = userConfig;
+  const commonOverrideConfig: Record<string, unknown> = {};
+  // GPT-6 does not support temperature; omit it from the serialized request.
+  commonOverrideConfig.temperature = undefined;
   if (responseFormat !== 'none' && expectedJsonObjectResponse) {
-    config.response_format = { type: 'json_object' };
+    commonOverrideConfig.response_format = { type: 'json_object' };
   }
 
-  return { config };
+  const effectiveReasoningEffort = resolveGpt6ReasoningEffort(userConfig);
+
+  return {
+    config: {
+      ...midsceneDefaults,
+      ...commonOverrideConfig,
+      reasoning_effort: effectiveReasoningEffort,
+    },
+  };
 };
 
 export const gptAdapters = {
   'gpt-5': {
+    buildCodexAppServerParams: buildGpt5CodexAppServerParams,
     chatCompletion: {
       unsupportedUserConfig: ['reasoningBudget'],
       buildChatCompletionParams: buildGpt5ChatCompletionParams,
@@ -82,6 +121,7 @@ export const gptAdapters = {
     },
   },
   'gpt-6': {
+    buildCodexAppServerParams: buildGpt6CodexAppServerParams,
     chatCompletion: {
       unsupportedUserConfig: ['temperature', 'reasoningBudget'],
       buildChatCompletionParams: buildGpt6ChatCompletionParams,

--- a/packages/core/src/ai-model/service-caller/codex-app-server.ts
+++ b/packages/core/src/ai-model/service-caller/codex-app-server.ts
@@ -3,13 +3,11 @@ import type {
   CodeGenerationChunk,
   StreamingCallback,
 } from '@/types';
-import type {
-  IModelConfig,
-  TModelReasoningEnabled,
-} from '@midscene/shared/env';
+import type { IModelConfig } from '@midscene/shared/env';
 import { getDebug } from '@midscene/shared/logger';
 import { ifInBrowser } from '@midscene/shared/utils';
 import type { ChatCompletionMessageParam } from 'openai/resources/index';
+import type { CodexAppServerParamsResult } from '../model-adapter/types';
 
 const CODEX_PROVIDER_SCHEME = 'codex://';
 const CODEX_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -19,14 +17,6 @@ const CODEX_TEXT_INPUT_MAX_LENGTH = 256 * 1024;
 
 const debugCodex = getDebug('ai:call:codex');
 const warnCodex = getDebug('ai:call:codex', { console: true });
-
-type CodexReasoningEffort =
-  | 'none'
-  | 'minimal'
-  | 'low'
-  | 'medium'
-  | 'high'
-  | 'xhigh';
 
 type JsonRpcRequest = {
   id: string | number;
@@ -293,30 +283,6 @@ const extractImageInputs = (
   return inputs;
 };
 
-export const resolveCodexReasoningEffort = ({
-  reasoningEnabled,
-  modelConfig,
-}: {
-  reasoningEnabled?: TModelReasoningEnabled;
-  modelConfig: IModelConfig;
-}): CodexReasoningEffort | undefined => {
-  if (reasoningEnabled !== true) return 'none';
-
-  const normalized = modelConfig.reasoningEffort?.trim().toLowerCase();
-  if (
-    normalized === 'none' ||
-    normalized === 'minimal' ||
-    normalized === 'low' ||
-    normalized === 'medium' ||
-    normalized === 'high' ||
-    normalized === 'xhigh'
-  ) {
-    return normalized;
-  }
-
-  return 'medium';
-};
-
 export const buildCodexTurnPayloadFromMessages = (
   messages: ChatCompletionMessageParam[],
   imageDetailOverride?: CodexImageDetail,
@@ -431,7 +397,7 @@ class CodexAppServerConnection {
     modelConfig,
     stream,
     onChunk,
-    reasoningEnabled,
+    params,
     abortSignal,
     imageDetail,
     onRecordEvent,
@@ -440,7 +406,7 @@ class CodexAppServerConnection {
     modelConfig: IModelConfig;
     stream?: boolean;
     onChunk?: StreamingCallback;
-    reasoningEnabled?: TModelReasoningEnabled;
+    params?: CodexAppServerParamsResult['config'];
     abortSignal?: AbortSignal;
     imageDetail?: CodexImageDetail;
     onRecordEvent?: (event: CodexAppServerRecordEvent) => void;
@@ -454,10 +420,6 @@ class CodexAppServerConnection {
       messages,
       imageDetail,
     );
-    const effort = resolveCodexReasoningEffort({
-      reasoningEnabled,
-      modelConfig,
-    });
 
     let threadId: string | undefined;
     let turnId: string | undefined;
@@ -528,9 +490,9 @@ class CodexAppServerConnection {
       }
 
       const turnStartParams = {
+        ...params,
         threadId,
         input,
-        effort,
       };
       onRecordEvent?.({
         type: 'request',
@@ -1026,7 +988,7 @@ class CodexAppServerConnectionManager {
     modelConfig,
     stream,
     onChunk,
-    reasoningEnabled,
+    params,
     abortSignal,
     imageDetail,
     onRecordEvent,
@@ -1035,7 +997,7 @@ class CodexAppServerConnectionManager {
     modelConfig: IModelConfig;
     stream?: boolean;
     onChunk?: StreamingCallback;
-    reasoningEnabled?: TModelReasoningEnabled;
+    params?: CodexAppServerParamsResult['config'];
     abortSignal?: AbortSignal;
     imageDetail?: CodexImageDetail;
     onRecordEvent?: (event: CodexAppServerRecordEvent) => void;
@@ -1048,7 +1010,7 @@ class CodexAppServerConnectionManager {
           modelConfig,
           stream,
           onChunk,
-          reasoningEnabled,
+          params,
           abortSignal,
           imageDetail,
           onRecordEvent,
@@ -1091,7 +1053,7 @@ export async function callAIWithCodexAppServer(
   options?: {
     stream?: boolean;
     onChunk?: StreamingCallback;
-    reasoningEnabled?: TModelReasoningEnabled;
+    params?: CodexAppServerParamsResult['config'];
     abortSignal?: AbortSignal;
     imageDetail?: CodexImageDetail;
     onRecordEvent?: (event: CodexAppServerRecordEvent) => void;
@@ -1108,7 +1070,7 @@ export async function callAIWithCodexAppServer(
     modelConfig,
     stream: options?.stream,
     onChunk: options?.onChunk,
-    reasoningEnabled: options?.reasoningEnabled,
+    params: options?.params,
     abortSignal: options?.abortSignal,
     imageDetail: options?.imageDetail,
     onRecordEvent: options?.onRecordEvent,

--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -399,7 +399,7 @@ export async function callAI(
         });
       }
     : undefined;
-  const chatCompletionInput = {
+  const modelCallInput = {
     intent: modelConfig.intent,
     userConfig: {
       temperature: modelConfig.temperature,
@@ -412,9 +412,6 @@ export async function callAI(
     requiresOriginalImageDetail: options?.requiresOriginalImageDetail,
     expectedJsonObjectResponse: options?.expectedJsonObjectResponse,
   };
-  const imageDetail =
-    adapter.chatCompletion.resolveImageDetail(chatCompletionInput);
-
   if (isCodexAppServerProvider(modelConfig.openaiBaseURL)) {
     let protocolChunkSequence = 0;
     const codexStartTime = Date.now();
@@ -440,13 +437,15 @@ export async function callAI(
       : undefined;
 
     try {
+      const { config, imageDetail } =
+        adapter.buildCodexAppServerParams(modelCallInput);
       const codexResult = await callAIWithCodexAppServer(
         messages,
         modelConfig,
         {
           stream: options?.stream,
           onChunk: options?.onChunk,
-          reasoningEnabled: modelConfig.reasoningEnabled,
+          params: config,
           abortSignal: options?.abortSignal,
           imageDetail,
           onRecordEvent: recordCodexEvent,
@@ -492,6 +491,8 @@ export async function callAI(
     }
   }
 
+  const imageDetail = adapter.chatCompletion.resolveImageDetail(modelCallInput);
+
   const {
     completion,
     modelName,
@@ -516,7 +517,7 @@ export async function callAI(
 
   const isStreaming = options?.stream && options?.onChunk;
   const { config: adapterChatCompletionParams } =
-    adapter.chatCompletion.buildChatCompletionParams(chatCompletionInput);
+    adapter.chatCompletion.buildChatCompletionParams(modelCallInput);
   debugCall(
     `adapter chat completion params: ${stringifyForDebug({
       config: adapterChatCompletionParams,

--- a/packages/core/tests/unit-test/codex-app-server-provider.test.ts
+++ b/packages/core/tests/unit-test/codex-app-server-provider.test.ts
@@ -1,13 +1,13 @@
 import { chmod, copyFile, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { ResolvedModelAdapter } from '@/ai-model/model-adapter/resolve';
 import {
   __shutdownCodexAppServerForTests,
   buildCodexTurnPayloadFromMessages,
   callAIWithCodexAppServer,
   isCodexAppServerProvider,
   normalizeCodexLocalImagePath,
-  resolveCodexReasoningEffort,
 } from '@/ai-model/service-caller/codex-app-server';
 import type { IModelConfig } from '@midscene/shared/env';
 import { afterEach, describe, expect, it, rs } from '@rstest/core';
@@ -51,102 +51,26 @@ describe('codex app-server provider helper', () => {
     expect(isCodexAppServerProvider(undefined)).toBe(false);
   });
 
-  it('maps reasoningEnabled and reasoning effort to codex effort', () => {
+  it('preserves default Codex parameter handling for other model families', () => {
+    const adapter = new ResolvedModelAdapter({}, 'default');
+    expect(adapter.buildCodexAppServerParams({}).config).toEqual({
+      effort: 'none',
+    });
     expect(
-      resolveCodexReasoningEffort({
-        reasoningEnabled: true,
-        modelConfig: baseModelConfig,
-      }),
-    ).toBe('medium');
-
+      adapter.buildCodexAppServerParams({
+        userConfig: { reasoningEnabled: true },
+      }).config,
+    ).toEqual({ effort: 'medium' });
     expect(
-      resolveCodexReasoningEffort({
-        reasoningEnabled: false,
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'xhigh',
-        },
-      }),
-    ).toBe('none');
-
+      adapter.buildCodexAppServerParams({
+        userConfig: { reasoningEnabled: true, reasoningEffort: ' XHIGH ' },
+      }).config,
+    ).toEqual({ effort: 'xhigh' });
     expect(
-      resolveCodexReasoningEffort({
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'medium',
-        },
-      }),
-    ).toBe('none');
-
-    expect(
-      resolveCodexReasoningEffort({
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'minimal',
-        },
-      }),
-    ).toBe('none');
-
-    expect(
-      resolveCodexReasoningEffort({
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'none',
-        },
-      }),
-    ).toBe('none');
-
-    expect(
-      resolveCodexReasoningEffort({
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'invalid-effort',
-        },
-      }),
-    ).toBe('none');
-
-    expect(
-      resolveCodexReasoningEffort({
-        modelConfig: baseModelConfig,
-      }),
-    ).toBe('none');
-
-    expect(
-      resolveCodexReasoningEffort({
-        reasoningEnabled: true,
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'xhigh',
-        },
-      }),
-    ).toBe('xhigh');
-
-    expect(
-      resolveCodexReasoningEffort({
-        reasoningEnabled: false,
-        modelConfig: baseModelConfig,
-      }),
-    ).toBe('none');
-
-    expect(
-      resolveCodexReasoningEffort({
-        reasoningEnabled: false,
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'medium',
-        },
-      }),
-    ).toBe('none');
-
-    expect(
-      resolveCodexReasoningEffort({
-        reasoningEnabled: 'default',
-        modelConfig: {
-          ...baseModelConfig,
-          reasoningEffort: 'medium',
-        },
-      }),
-    ).toBe('none');
+      adapter.buildCodexAppServerParams({
+        userConfig: { reasoningEnabled: true, reasoningEffort: 'invalid' },
+      }).config,
+    ).toEqual({ effort: 'medium' });
   });
 
   it('converts chat messages into codex turn payload', () => {
@@ -369,7 +293,10 @@ readline.on('line', (line) => {
     const result = await callAIWithCodexAppServer(
       [{ role: 'user', content: 'hello' }],
       baseModelConfig,
-      { onRecordEvent: (event) => events.push(event) },
+      {
+        params: { effort: 'max' },
+        onRecordEvent: (event) => events.push(event),
+      },
     );
 
     expect(result).toMatchObject({
@@ -389,7 +316,10 @@ readline.on('line', (line) => {
         }),
         expect.objectContaining({
           type: 'request',
-          protocol: expect.objectContaining({ method: 'turn/start' }),
+          protocol: expect.objectContaining({
+            method: 'turn/start',
+            params: expect.objectContaining({ effort: 'max' }),
+          }),
         }),
         expect.objectContaining({
           type: 'chunk',

--- a/packages/core/tests/unit-test/gpt-image-detail.test.ts
+++ b/packages/core/tests/unit-test/gpt-image-detail.test.ts
@@ -183,4 +183,26 @@ describe('GPT image detail handling', () => {
 
     expect(mockCreate.mock.calls[0][0]).toHaveProperty('temperature', 0.7);
   });
+
+  it('sends GPT-6 screenshots through Chat Completions with compatible defaults', async () => {
+    await callAI(
+      imageMessage,
+      getModelRuntime({
+        ...baseModelConfig,
+        modelFamily: 'gpt-6',
+        modelName: 'gpt-6-astra',
+        temperature: 0.7,
+      }),
+      { semanticRetryAttempt: 1, expectedJsonObjectResponse: true },
+    );
+
+    const request = mockCreate.mock.calls[0][0];
+    expect(request).toMatchObject({
+      model: 'gpt-6-astra',
+      reasoning_effort: 'low',
+      response_format: { type: 'json_object' },
+    });
+    expect(request).not.toHaveProperty('temperature');
+    expect(request.messages[0].content[0].image_url.detail).toBe('original');
+  });
 });

--- a/packages/core/tests/unit-test/gpt-image-detail.test.ts
+++ b/packages/core/tests/unit-test/gpt-image-detail.test.ts
@@ -4,6 +4,12 @@ import type { IModelConfig } from '@midscene/shared/env';
 import { beforeEach, describe, expect, it, rs } from '@rstest/core';
 
 const mockCreate = rs.fn();
+const mockCodexCall = rs.hoisted(() => rs.fn());
+
+rs.mock('@/ai-model/service-caller/codex-app-server', () => ({
+  isCodexAppServerProvider: (url?: string) => url === 'codex://app-server',
+  callAIWithCodexAppServer: mockCodexCall,
+}));
 
 rs.mock('openai', () => ({
   default: rs.fn().mockImplementation(() => ({
@@ -46,6 +52,8 @@ const imageMessage = [
 
 describe('GPT image detail handling', () => {
   beforeEach(() => {
+    mockCodexCall.mockReset();
+    mockCodexCall.mockResolvedValue({ content: 'ok', isStreamed: false });
     mockCreate.mockReset();
     mockCreate.mockResolvedValue({
       choices: [{ message: { content: 'ok' } }],
@@ -56,6 +64,75 @@ describe('GPT image detail handling', () => {
       },
     });
   });
+
+  it.each([undefined, 'max'])(
+    'passes resolved GPT-6 effort to Codex for %s',
+    async (reasoningEffort) => {
+      await callAI(
+        imageMessage,
+        getModelRuntime({
+          ...baseModelConfig,
+          modelName: 'gpt-6-astra',
+          modelFamily: 'gpt-6',
+          openaiBaseURL: 'codex://app-server',
+          reasoningEnabled: true,
+          reasoningEffort,
+        }),
+      );
+      expect(mockCodexCall).toHaveBeenCalledWith(
+        imageMessage,
+        expect.anything(),
+        expect.objectContaining({
+          params: { effort: reasoningEffort ?? 'medium' },
+          imageDetail: 'original',
+        }),
+      );
+      expect(mockCreate).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      intent: 'default',
+      requiresOriginalImageDetail: false,
+      expected: 'original',
+    },
+    {
+      intent: 'planning',
+      requiresOriginalImageDetail: false,
+      expected: undefined,
+    },
+    {
+      intent: 'planning',
+      requiresOriginalImageDetail: true,
+      expected: 'original',
+    },
+  ] as const)(
+    'resolves Codex image detail independently for %j',
+    async ({ intent, requiresOriginalImageDetail, expected }) => {
+      for (const modelFamily of ['gpt-5', 'gpt-6'] as const) {
+        const runtime = getModelRuntime({
+          ...baseModelConfig,
+          modelFamily,
+          intent,
+          openaiBaseURL: 'codex://app-server',
+        });
+        const chatDetailSpy = rs.spyOn(
+          runtime.adapter.chatCompletion,
+          'resolveImageDetail',
+        );
+        try {
+          await callAI(imageMessage, runtime, { requiresOriginalImageDetail });
+          expect(mockCodexCall.mock.calls.at(-1)?.[2].imageDetail).toBe(
+            expected,
+          );
+          expect(chatDetailSpy).not.toHaveBeenCalled();
+        } finally {
+          chatDetailSpy.mockRestore();
+        }
+      }
+    },
+  );
 
   it('overrides image detail to original for gpt-5 default intent requests', async () => {
     await callAI(imageMessage, getModelRuntime(baseModelConfig));
@@ -202,7 +279,9 @@ describe('GPT image detail handling', () => {
       reasoning_effort: 'low',
       response_format: { type: 'json_object' },
     });
-    expect(request).not.toHaveProperty('temperature');
+    expect(JSON.parse(JSON.stringify(request))).not.toHaveProperty(
+      'temperature',
+    );
     expect(request.messages[0].content[0].image_url.detail).toBe('original');
   });
 });

--- a/packages/core/tests/unit-test/model-adapter/gpt.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/gpt.test.ts
@@ -3,6 +3,70 @@ import { gptAdapters } from '@/ai-model/models/gpt';
 import { describe, expect, it } from '@rstest/core';
 
 const gpt5Adapter = new ResolvedModelAdapter(gptAdapters['gpt-5'], 'gpt-5');
+const gpt6Adapter = new ResolvedModelAdapter(gptAdapters['gpt-6'], 'gpt-6');
+
+describe('gpt-6 model adapter', () => {
+  it.each([undefined, true, false])(
+    'defaults reasoning to low when enabled=%s',
+    (reasoningEnabled) => {
+      expect(
+        gpt6Adapter.chatCompletion.buildChatCompletionParams({
+          userConfig: { reasoningEnabled },
+        }).config,
+      ).toEqual({ reasoning_effort: 'low' });
+    },
+  );
+
+  it.each(['low', 'medium', 'high', 'xhigh', 'max'])(
+    'supports explicit effort %s',
+    (reasoningEffort) => {
+      expect(
+        gpt6Adapter.chatCompletion.buildChatCompletionParams({
+          userConfig: { reasoningEffort },
+        }).config.reasoning_effort,
+      ).toBe(reasoningEffort);
+    },
+  );
+
+  it('uses low even with explicit effort when reasoning is disabled', () => {
+    expect(
+      gpt6Adapter.chatCompletion.buildChatCompletionParams({
+        userConfig: { reasoningEnabled: false, reasoningEffort: 'high' },
+      }).config.reasoning_effort,
+    ).toBe('low');
+  });
+
+  it.each([0, 1])(
+    'omits temperature and reasoning budget on retry %s',
+    (semanticRetryAttempt) => {
+      expect(
+        gpt6Adapter.chatCompletion.buildChatCompletionParams({
+          userConfig: { temperature: 0.7, reasoningBudget: 1024 },
+          semanticRetryAttempt,
+        }).config,
+      ).toEqual({ reasoning_effort: 'low' });
+      expect(
+        gpt6Adapter.chatCompletion.buildChatCompletionParams({
+          semanticRetryAttempt,
+        }).config,
+      ).toEqual({ reasoning_effort: 'low' });
+    },
+  );
+
+  it('uses JSON mode only when requested and not disabled', () => {
+    expect(
+      gpt6Adapter.chatCompletion.buildChatCompletionParams({
+        expectedJsonObjectResponse: true,
+      }).config.response_format,
+    ).toEqual({ type: 'json_object' });
+    expect(
+      gpt6Adapter.chatCompletion.buildChatCompletionParams({
+        expectedJsonObjectResponse: true,
+        userConfig: { responseFormat: 'none' },
+      }).config.response_format,
+    ).toBeUndefined();
+  });
+});
 
 describe('gpt model adapter', () => {
   it('keeps GPT-5 image-detail policy in the adapter', () => {

--- a/packages/core/tests/unit-test/model-adapter/gpt.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/gpt.test.ts
@@ -5,8 +5,59 @@ import { describe, expect, it } from '@rstest/core';
 const gpt5Adapter = new ResolvedModelAdapter(gptAdapters['gpt-5'], 'gpt-5');
 const gpt6Adapter = new ResolvedModelAdapter(gptAdapters['gpt-6'], 'gpt-6');
 
+describe('GPT Codex App Server parameters', () => {
+  it.each([
+    {},
+    { reasoningEnabled: true },
+    { reasoningEnabled: false },
+    { reasoningEffort: 'max' },
+    { reasoningEnabled: true, reasoningEffort: 'high' },
+    { reasoningEnabled: false, reasoningEffort: 'max' },
+  ] as const)(
+    'shares reasoning policy across providers for %j',
+    (userConfig) => {
+      for (const adapter of [gpt5Adapter, gpt6Adapter]) {
+        expect(
+          adapter.buildCodexAppServerParams({ userConfig }).config,
+        ).toEqual({
+          effort: adapter.chatCompletion.buildChatCompletionParams({
+            userConfig,
+          }).config.reasoning_effort,
+        });
+      }
+    },
+  );
+});
+
+describe('GPT provider-default reasoning', () => {
+  it.each([undefined, 'high', 'max'])(
+    'omits reasoning controls even with effort %s',
+    (reasoningEffort) => {
+      for (const adapter of [gpt5Adapter, gpt6Adapter]) {
+        const input = {
+          userConfig: {
+            reasoningEnabled: 'default' as const,
+            reasoningEffort,
+            reasoningBudget: 1024,
+          },
+        };
+        const chatConfig =
+          adapter.chatCompletion.buildChatCompletionParams(input).config;
+        const codexConfig = adapter.buildCodexAppServerParams(input).config;
+        expect(JSON.parse(JSON.stringify(chatConfig))).not.toHaveProperty(
+          'reasoning_effort',
+        );
+        expect(JSON.parse(JSON.stringify(codexConfig))).not.toHaveProperty(
+          'effort',
+        );
+        expect(chatConfig).not.toHaveProperty('reasoning_budget');
+      }
+    },
+  );
+});
+
 describe('gpt-6 model adapter', () => {
-  it.each([undefined, true, false])(
+  it.each([undefined, false])(
     'defaults reasoning to low when enabled=%s',
     (reasoningEnabled) => {
       expect(
@@ -17,24 +68,35 @@ describe('gpt-6 model adapter', () => {
     },
   );
 
+  it('defaults enabled reasoning to medium', () => {
+    expect(
+      gpt6Adapter.chatCompletion.buildChatCompletionParams({
+        userConfig: { reasoningEnabled: true },
+      }).config.reasoning_effort,
+    ).toBe('medium');
+  });
+
   it.each(['low', 'medium', 'high', 'xhigh', 'max'])(
     'supports explicit effort %s',
     (reasoningEffort) => {
       expect(
         gpt6Adapter.chatCompletion.buildChatCompletionParams({
-          userConfig: { reasoningEffort },
+          userConfig: { reasoningEnabled: true, reasoningEffort },
         }).config.reasoning_effort,
       ).toBe(reasoningEffort);
     },
   );
 
-  it('uses low even with explicit effort when reasoning is disabled', () => {
-    expect(
-      gpt6Adapter.chatCompletion.buildChatCompletionParams({
-        userConfig: { reasoningEnabled: false, reasoningEffort: 'high' },
-      }).config.reasoning_effort,
-    ).toBe('low');
-  });
+  it.each([undefined, false])(
+    'ignores explicit effort when enabled=%s',
+    (reasoningEnabled) => {
+      expect(
+        gpt6Adapter.chatCompletion.buildChatCompletionParams({
+          userConfig: { reasoningEnabled, reasoningEffort: 'high' },
+        }).config.reasoning_effort,
+      ).toBe('low');
+    },
+  );
 
   it.each([0, 1])(
     'omits temperature and reasoning budget on retry %s',

--- a/packages/shared/src/env/types.ts
+++ b/packages/shared/src/env/types.ts
@@ -314,6 +314,7 @@ export type TModelFamily =
   | 'auto-glm'
   | 'auto-glm-multilingual'
   | 'gpt-5'
+  | 'gpt-6'
   | 'deepseek'
   | 'kimi'
   | 'kimi3'
@@ -335,6 +336,7 @@ export const MODEL_FAMILY_VALUES: TModelFamily[] = [
   'auto-glm',
   'auto-glm-multilingual',
   'gpt-5',
+  'gpt-6',
   'deepseek',
   'kimi',
   'kimi3',

--- a/packages/shared/tests/unit-test/env/parse.test.ts
+++ b/packages/shared/tests/unit-test/env/parse.test.ts
@@ -52,6 +52,7 @@ describe('validateModelFamily', () => {
     expect(() => validateModelFamily('gemini')).not.toThrow();
     expect(() => validateModelFamily('glm-v')).not.toThrow();
     expect(() => validateModelFamily('gpt-5')).not.toThrow();
+    expect(() => validateModelFamily('gpt-6')).not.toThrow();
     expect(() => validateModelFamily('kimi')).not.toThrow();
     expect(() => validateModelFamily('xiaomi-mimo')).not.toThrow();
     expect(() => validateModelFamily('vlm-ui-tars')).not.toThrow();


### PR DESCRIPTION
Adds the `gpt-6` model family for `gpt-6-astra`. The adapter uses `low` when reasoning is disabled, defaults enabled reasoning to `medium`, leaves effort unspecified for `default`, and omits unsupported temperature from Chat Completions requests. GPT-5 also preserves provider defaults when reasoning is set to `default`.

Moves Codex App Server effort and image-detail selection into the model adapters through `buildCodexAppServerParams`, keeping GPT behavior aligned across both transports while preserving the existing fallback for other models. Updates the English and Chinese configuration docs with GPT-6 examples and Fast mode usage.

### Validation

- `pnpm run lint` — passed; rerun before PR creation, no fixes applied.
- `pnpm exec nx test @midscene/core -- tests/unit-test/model-adapter/gpt.test.ts tests/unit-test/gpt-image-detail.test.ts tests/unit-test/codex-app-server-provider.test.ts` — 52 tests passed before commit.
- `pnpm exec nx build @midscene/core` — passed before commit.

Unit tests cover reasoning defaults and overrides, image detail, serialized temperature omission, and Codex effort forwarding. Live model behavior is not established by these checks.