### PR TITLE
fix(core): unify normalized coordinate mapping and rounding

### DIFF
--- a/packages/core/src/ai-model/models/deepseek/adapter.ts
+++ b/packages/core/src/ai-model/models/deepseek/adapter.ts
@@ -17,12 +17,14 @@ const deepSeekPointCoordinates = {
   shape: 'point',
   order: 'xy',
   normalizedBy: 1000,
+  rounding: 'round',
 } as const;
 
 const deepSeekBboxCoordinates = {
   shape: 'bbox',
   order: 'xy',
   normalizedBy: 1000,
+  rounding: 'round',
 } as const;
 
 function parseDeepSeekCoordinateValues(

--- a/packages/core/src/ai-model/models/doubao.ts
+++ b/packages/core/src/ai-model/models/doubao.ts
@@ -15,11 +15,13 @@ const doubaoBboxCoordinatesMeta = {
   shape: 'bbox',
   order: 'xy',
   normalizedBy: 1000,
+  rounding: 'round',
 } as const;
 const doubaoPointCoordinatesMeta = {
   shape: 'point',
   order: 'xy',
   normalizedBy: 1000,
+  rounding: 'round',
 } as const;
 
 /**

--- a/packages/core/src/ai-model/models/kimi.ts
+++ b/packages/core/src/ai-model/models/kimi.ts
@@ -14,10 +14,12 @@ const kimiNormalizedPointCoordinatesMeta = {
   shape: 'point',
   order: 'xy',
   normalizedBy: 1,
+  rounding: 'round',
 } as const;
 const kimiPixelPointCoordinatesMeta = {
   shape: 'point',
   order: 'xy',
+  rounding: 'round',
 } as const;
 
 function parseKimiRawLocateValue(input: unknown): LocateResultValue {

--- a/packages/core/src/ai-model/models/qwen.ts
+++ b/packages/core/src/ai-model/models/qwen.ts
@@ -13,15 +13,18 @@ import {
 const qwen25BboxCoordinatesMeta = {
   shape: 'bbox',
   order: 'xy',
+  rounding: 'round',
 } as const;
 const qwen25PointCoordinatesMeta = {
   shape: 'point',
   order: 'xy',
+  rounding: 'round',
 } as const;
 const qwen3BboxCoordinatesMeta = {
   shape: 'bbox',
   order: 'xy',
   normalizedBy: 1000,
+  rounding: 'round',
 } as const;
 
 function parseQwen25RawLocateValue(input: unknown): LocateResultValue {

--- a/packages/core/src/ai-model/models/ui-tars/adapter.ts
+++ b/packages/core/src/ai-model/models/ui-tars/adapter.ts
@@ -13,11 +13,13 @@ const uiTarsBboxCoordinatesMeta = {
   shape: 'bbox',
   order: 'xy',
   normalizedBy: 1000,
+  rounding: 'round',
 } as const;
 const uiTarsPointCoordinatesMeta = {
   shape: 'point',
   order: 'xy',
   normalizedBy: 1000,
+  rounding: 'round',
 } as const;
 
 // UI-TARS has not received active updates for a long time, so this parser is

--- a/packages/core/src/ai-model/shared/model-locate-result/coordinate-distance.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/coordinate-distance.ts
@@ -1,4 +1,5 @@
 import type { Size } from '@/types';
+import { normalizedCoordinateToPixel } from './pixel-mapper';
 import type { ResolvedLocateResultCoordinates } from './types';
 
 export type CoordinateDistanceAxis = 'x' | 'y';
@@ -13,8 +14,11 @@ export function createCoordinateDistanceToPixels(
     }
 
     const length = axis === 'x' ? size.width : size.height;
-    return Math.round(
-      (Math.abs(delta) * length) / coordinateSystem.normalizedBy,
+    return normalizedCoordinateToPixel(
+      Math.abs(delta),
+      coordinateSystem.normalizedBy,
+      length,
+      coordinateSystem.rounding,
     );
   };
 }

--- a/packages/core/src/ai-model/shared/model-locate-result/factory.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/factory.ts
@@ -22,7 +22,6 @@ import {
 export function resolveLocateResultCoordinates(
   coordinates: LocateResultCoordinates,
 ): ResolvedLocateResultCoordinates {
-  const order = coordinates.order ?? 'xy';
   if (coordinates.normalizedBy !== undefined && coordinates.normalizedBy <= 0) {
     throw new Error(
       `locate result coordinates normalizedBy must be positive: ${coordinates.normalizedBy}`,
@@ -30,8 +29,9 @@ export function resolveLocateResultCoordinates(
   }
   return {
     shape: coordinates.shape,
-    order,
+    order: coordinates.order ?? 'xy',
     normalizedBy: coordinates.normalizedBy,
+    rounding: coordinates.rounding ?? 'round',
   };
 }
 

--- a/packages/core/src/ai-model/shared/model-locate-result/index.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/index.ts
@@ -15,6 +15,7 @@ export {
   unwrapCoordinateListLikeInput,
 } from './parse';
 export type {
+  CoordinateRounding,
   LocateResultBbox,
   PixelBbox,
   PixelLocateResult,

--- a/packages/core/src/ai-model/shared/model-locate-result/pixel-mapper.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/pixel-mapper.ts
@@ -2,6 +2,7 @@ import type { Rect } from '@/types';
 import { isBboxLocateResultValue } from './types';
 import type {
   BboxLocateResultValue,
+  CoordinateRounding,
   LocateResultPoint,
   LocateResultValue,
   PixelBbox,
@@ -19,8 +20,19 @@ export function normalizedCoordinateToPixel(
   value: number,
   normalizedBy: number,
   size: number,
+  rounding: CoordinateRounding,
 ) {
-  return Math.round((value * maxPixelCoordinate(size)) / normalizedBy);
+  const pixel = (value * size) / normalizedBy;
+  switch (rounding) {
+    case 'round':
+      return Math.round(pixel);
+    case 'trunc':
+      return Math.trunc(pixel);
+    case 'none':
+      return pixel;
+    default:
+      throw new Error(`Invalid coordinate rounding: ${rounding}`);
+  }
 }
 
 /** Restrict an already mapped point to the effective content area. */
@@ -59,17 +71,17 @@ export function mapLocateResultToPixelBbox(
   result: BboxLocateResultValue,
   { width, height }: { width: number; height: number },
 ): PixelBbox {
-  const { normalizedBy, order } = result.coordinatesMeta;
+  const { normalizedBy, order, rounding } = result.coordinatesMeta;
   const [first, second, third, fourth] = result.coordinates;
   const xyBbox: PixelBbox =
     order === 'yx' ? [second, first, fourth, third] : result.coordinates;
   return normalizedBy === undefined
     ? xyBbox
     : [
-        normalizedCoordinateToPixel(xyBbox[0], normalizedBy, width),
-        normalizedCoordinateToPixel(xyBbox[1], normalizedBy, height),
-        normalizedCoordinateToPixel(xyBbox[2], normalizedBy, width),
-        normalizedCoordinateToPixel(xyBbox[3], normalizedBy, height),
+        normalizedCoordinateToPixel(xyBbox[0], normalizedBy, width, rounding),
+        normalizedCoordinateToPixel(xyBbox[1], normalizedBy, height, rounding),
+        normalizedCoordinateToPixel(xyBbox[2], normalizedBy, width, rounding),
+        normalizedCoordinateToPixel(xyBbox[3], normalizedBy, height, rounding),
       ];
 }
 
@@ -78,7 +90,7 @@ export function mapLocateResultToPixelPoint(
   result: LocateResultValue,
   { width, height }: { width: number; height: number },
 ): LocateResultPoint {
-  const { order, normalizedBy } = result.coordinatesMeta;
+  const { order, normalizedBy, rounding } = result.coordinatesMeta;
   const [first, second] = isBboxLocateResultValue(result)
     ? [
         (result.coordinates[0] + result.coordinates[2]) / 2,
@@ -89,7 +101,7 @@ export function mapLocateResultToPixelPoint(
   return normalizedBy === undefined
     ? [x, y]
     : [
-        normalizedCoordinateToPixel(x, normalizedBy, width),
-        normalizedCoordinateToPixel(y, normalizedBy, height),
+        normalizedCoordinateToPixel(x, normalizedBy, width, rounding),
+        normalizedCoordinateToPixel(y, normalizedBy, height, rounding),
       ];
 }

--- a/packages/core/src/ai-model/shared/model-locate-result/types.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/types.ts
@@ -69,7 +69,7 @@ export interface LocateResultPromptSpec {
 }
 
 export interface PixelLocateResult {
-  /** Raw bbox midpoint (or raw point), mapped to the locate image; normalized coordinates are rounded to pixels. */
+  /** Raw bbox midpoint (or raw point), mapped to the locate image using the configured rounding. */
   center: LocateResultPoint;
   /**
    * Original bbox mapped to locate-image pixels and clipped to content bounds.
@@ -87,24 +87,31 @@ export interface LocateResultCodec {
   ): PixelLocateResult;
 }
 
+export type CoordinateRounding = 'round' | 'trunc' | 'none';
+
 export interface LocateResultCoordinates {
   shape: LocateResultShape;
   /** Axis order in the raw coordinates; defaults to xy. */
   order?: 'xy' | 'yx';
   /** Normalization range, e.g. 1 or 1000. Omit for model-image pixel coordinates. */
   normalizedBy?: number;
+  /** Rounding after normalized-to-pixel mapping; defaults to round. Pixel inputs retain their precision. */
+  rounding?: CoordinateRounding;
 }
 
+/** Coordinate metadata with defaults resolved and an explicit rounding policy. */
 export type ResolvedLocateResultCoordinates =
   | {
       shape: 'point';
       order: 'xy' | 'yx';
       normalizedBy?: number;
+      rounding: CoordinateRounding;
     }
   | {
       shape: 'bbox';
       order: 'xy' | 'yx';
       normalizedBy?: number;
+      rounding: CoordinateRounding;
     };
 
 export type RawLocateValueParser = (input: RawLocateValue) => LocateResultValue;
@@ -114,7 +121,8 @@ export type RawLocateValueParser = (input: RawLocateValue) => LocateResultValue;
  * The operation protocol extracts target/reference values from the response;
  * the codec parses each value once and maps it to `{ center, rect }` using the
  * parsed result's coordinatesMeta. Rect is undefined for actual point results.
- * Only raw-value parsing is customizable; coordinate mapping is shared.
+ * Raw-value parsing and normalized-coordinate rounding are configurable;
+ * coordinate mapping is shared.
  */
 export type LocateResultFormatDefinition = {
   /**
@@ -126,7 +134,8 @@ export type LocateResultFormatDefinition = {
    * Optional model-specific parser for nonstandard formats or point/bbox fallback.
    * Return `{ coordinates, coordinatesMeta }` describing the actual shape, axis
    * order, and normalization. Preserve coordinate precision; do not round or map
-   * to pixels here. Omit to parse numeric values according to `coordinates`.
+   * to pixels here. Include an explicit rounding policy in `coordinatesMeta`.
+   * Omit the parser to parse numeric values according to `coordinates`.
    */
   parseRawLocateValue?: RawLocateValueParser;
 };

--- a/packages/core/src/ai-model/shared/model-locate-result/validation.ts
+++ b/packages/core/src/ai-model/shared/model-locate-result/validation.ts
@@ -40,7 +40,10 @@ export function assertLocateResultStructure(result: LocateResultValue): void {
     );
   }
 
-  const { order, normalizedBy } = coordinatesMeta;
+  const { order, normalizedBy, rounding } = coordinatesMeta;
+  if (!['round', 'trunc', 'none'].includes(rounding)) {
+    throw new Error(`invalid locate coordinate rounding: ${rounding}`);
+  }
   if (order !== 'xy' && order !== 'yx') {
     throw new Error(
       `invalid locate coordinate order: ${JSON.stringify(order)}`,

--- a/packages/core/tests/unit-test/llm-planning.test.ts
+++ b/packages/core/tests/unit-test/llm-planning.test.ts
@@ -72,8 +72,8 @@ describe('llm planning - doubao', () => {
     expect(locatedPoint).toEqual({
       left: 123,
       top: 123,
-      width: 800,
-      height: 800,
+      width: 801,
+      height: 801,
     });
   });
 

--- a/packages/core/tests/unit-test/locate-normalization.test.ts
+++ b/packages/core/tests/unit-test/locate-normalization.test.ts
@@ -214,11 +214,19 @@ it.each(['bbox', 'point'] as const)(
       shape === 'bbox'
         ? {
             coordinates: [10, 20, 31, 41] as [number, number, number, number],
-            coordinatesMeta: { shape: 'bbox' as const, order: 'xy' as const },
+            coordinatesMeta: {
+              shape: 'bbox' as const,
+              order: 'xy' as const,
+              rounding: 'round' as const,
+            },
           }
         : {
             coordinates: [20.5, 30.5] as [number, number],
-            coordinatesMeta: { shape: 'point' as const, order: 'xy' as const },
+            coordinatesMeta: {
+              shape: 'point' as const,
+              order: 'xy' as const,
+              rounding: 'round' as const,
+            },
           },
     );
     // A bbox-configured model may still return a native point for this response.

--- a/packages/core/tests/unit-test/locate-point.test.ts
+++ b/packages/core/tests/unit-test/locate-point.test.ts
@@ -91,7 +91,7 @@ describe('point-based grounding', () => {
     const codec = createLocateResultCodec({
       coordinates: { shape: 'bbox', normalizedBy: 1000 },
     });
-    expect(codec.toPixelResult([0, 0, 10, 0], context)).toEqual({
+    expect(codec.toPixelResult([0, 0, 9, 0], context)).toEqual({
       center: [0, 0],
       rect: { left: 0, top: 0, width: 2, height: 1 },
     });
@@ -102,7 +102,11 @@ describe('point-based grounding', () => {
       coordinates: { shape: 'bbox' },
       parseRawLocateValue: () => ({
         coordinates: [0.25, 0.5],
-        coordinatesMeta: { shape: 'point', order: 'xy' },
+        coordinatesMeta: {
+          shape: 'point',
+          order: 'xy',
+          rounding: 'round' as const,
+        },
       }),
     });
     expect(codec.toPixelResult('fallback point', context).center).toEqual([

--- a/packages/core/tests/unit-test/locate-result-codec.test.ts
+++ b/packages/core/tests/unit-test/locate-result-codec.test.ts
@@ -1,4 +1,8 @@
-import { createLocateResultCodec } from '@/ai-model/shared/model-locate-result';
+import {
+  createCoordinateDistanceToPixels,
+  createLocateResultCodec,
+  resolveLocateResultCoordinates,
+} from '@/ai-model/shared/model-locate-result';
 import { locateResultExampleRegions } from '@/ai-model/shared/model-locate-result/prompt-spec';
 import { describe, expect, it } from '@rstest/core';
 
@@ -7,6 +11,143 @@ const locateCtx = (width: number, height: number) => ({
 });
 
 describe('createLocateResultCodec', () => {
+  it.each([undefined, 'invalid'])(
+    'rejects custom parser metadata without valid rounding: %s',
+    (rounding) => {
+      const codec = createLocateResultCodec({
+        coordinates: { shape: 'point' },
+        parseRawLocateValue: () => ({
+          coordinates: [10, 20],
+          coordinatesMeta: {
+            shape: 'point',
+            order: 'xy',
+            rounding: rounding as any,
+          },
+        }),
+      });
+      expect(() => codec.toPixelResult(null, locateCtx(100, 80))).toThrow(
+        /invalid locate coordinate rounding/,
+      );
+    },
+  );
+  it('resolves default rounding before mapping positions and distances', () => {
+    const coordinates = resolveLocateResultCoordinates({
+      shape: 'point',
+      normalizedBy: 1000,
+    });
+    expect(coordinates.rounding).toBe('round');
+    const size = { width: 101, height: 81 };
+    expect(createCoordinateDistanceToPixels(size, coordinates)(375, 'x')).toBe(
+      38,
+    );
+    expect(
+      createLocateResultCodec({ coordinates }).toPixelResult([375, 500], {
+        preparedSize: size,
+      }).center,
+    ).toEqual([38, 41]);
+  });
+  it('maps normalized coordinates using the full image size before clamping', () => {
+    const codec = createLocateResultCodec({
+      coordinates: { shape: 'point', normalizedBy: 1000 },
+    });
+    expect(
+      codec.toPixelResult([999, 999], locateCtx(2000, 1000)).center,
+    ).toEqual([1998, 999]);
+    expect(
+      codec.toPixelResult([1000, 1000], locateCtx(2000, 1000)).center,
+    ).toEqual([1999, 999]);
+  });
+
+  it.each([
+    {
+      rounding: 'round',
+      center: [38, 41],
+      rect: { left: 13, top: 20, width: 51, height: 42 },
+    },
+    {
+      rounding: 'trunc',
+      center: [37, 40],
+      rect: { left: 12, top: 20, width: 52, height: 41 },
+    },
+    {
+      rounding: 'none',
+      center: [37.875, 40.5],
+      rect: { left: 12.625, top: 20.25, width: 51.5, height: 41.5 },
+    },
+  ] as const)(
+    'applies $rounding consistently to positions, bbox metadata and distances',
+    ({ rounding, center, rect }) => {
+      const coordinates = {
+        shape: 'point',
+        order: 'xy',
+        normalizedBy: 1000,
+        rounding,
+      } as const;
+      const size = { width: 101, height: 81 };
+      const pointCodec = createLocateResultCodec({ coordinates });
+      const bboxCodec = createLocateResultCodec({
+        coordinates: { ...coordinates, shape: 'bbox' },
+      });
+      const distanceToPixels = createCoordinateDistanceToPixels(
+        size,
+        coordinates,
+      );
+      expect(
+        pointCodec.toPixelResult([375, 500], { preparedSize: size }).center,
+      ).toEqual(center);
+      expect(
+        bboxCodec.toPixelResult([125, 250, 625, 750], { preparedSize: size }),
+      ).toEqual({ center, rect });
+      expect([distanceToPixels(-375, 'x'), distanceToPixels(500, 'y')]).toEqual(
+        center,
+      );
+      expect(
+        pointCodec.toPixelResult([1000, 1000], { preparedSize: size }).center,
+      ).toEqual([100, 80]);
+      expect([
+        distanceToPixels(1000, 'x'),
+        distanceToPixels(-1000, 'y'),
+      ]).toEqual([101, 81]);
+    },
+  );
+
+  it.each([
+    { rounding: 'trunc', center: [37, 40] },
+    { rounding: 'round', center: [38, 41] },
+    { rounding: 'none', center: [37.875, 40.5] },
+  ] as const)(
+    'uses the explicit $rounding policy from custom parser metadata',
+    ({ rounding, center }) => {
+      const codec = createLocateResultCodec({
+        coordinates: { shape: 'bbox', normalizedBy: 1000, rounding: 'trunc' },
+        parseRawLocateValue: () => ({
+          coordinates: [0.375, 0.5],
+          coordinatesMeta: {
+            shape: 'point',
+            order: 'xy',
+            normalizedBy: 1,
+            rounding,
+          },
+        }),
+      });
+      expect(codec.toPixelResult(null, locateCtx(101, 81)).center).toEqual(
+        center,
+      );
+    },
+  );
+
+  it.each(['round', 'trunc', 'none'] as const)(
+    'preserves pixel input precision with rounding=%s',
+    (rounding) => {
+      const codec = createLocateResultCodec({
+        coordinates: { shape: 'point', rounding },
+      });
+      expect(
+        codec.toPixelResult([10.75, 20.5], locateCtx(100, 80)).center,
+      ).toEqual([10.75, 20.5]);
+    },
+  );
+
   it('uses valid xyxy regions for built-in prompt examples', () => {
     for (const [xmin, ymin, xmax, ymax] of locateResultExampleRegions) {
       expect(xmin).toBeGreaterThanOrEqual(0);
@@ -155,7 +296,12 @@ describe('createLocateResultCodec', () => {
       coordinates: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
       parseRawLocateValue: () => ({
         coordinates: [652, '233; 713 251;'] as any,
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       }),
     });
 
@@ -250,7 +396,12 @@ describe('createLocateResultCodec', () => {
         coordinates: { shape: 'point' },
         parseRawLocateValue: () => ({
           coordinates: [10, 20],
-          coordinatesMeta: { shape: 'point', order: 'xy', normalizedBy },
+          coordinatesMeta: {
+            shape: 'point',
+            order: 'xy',
+            normalizedBy,
+            rounding: 'round' as const,
+          },
         }),
       });
       expect(() => codec.toPixelResult(null, locateCtx(100, 80))).toThrow(
@@ -264,7 +415,11 @@ describe('createLocateResultCodec', () => {
       coordinates: { shape: 'point' },
       parseRawLocateValue: () => ({
         coordinates: [10, 20],
-        coordinatesMeta: { shape: 'point', order: 'invalid' as any },
+        coordinatesMeta: {
+          shape: 'point',
+          order: 'invalid' as any,
+          rounding: 'round' as const,
+        },
       }),
     });
     expect(() => codec.toPixelResult(null, locateCtx(100, 80))).toThrow(

--- a/packages/core/tests/unit-test/model-adapter/auto-glm/planning.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/auto-glm/planning.test.ts
@@ -99,6 +99,37 @@ describe('createAutoGlmPlanner', () => {
     rs.mocked(callAIWithStringResponse).mockReset();
   });
 
+  it.each([
+    { rounding: 'round', center: [38, 41], distance: 38 },
+    { rounding: 'trunc', center: [37, 40], distance: 37 },
+    { rounding: 'none', center: [37.875, 40.5], distance: 37.875 },
+  ] as const)(
+    'passes adapter rounding=$rounding to both swipe position and distance',
+    async ({ rounding, center, distance }) => {
+      rs.mocked(callAIWithStringResponse).mockResolvedValueOnce({
+        content:
+          '<think>Swipe left</think><answer>do(action="Swipe", start=[375,500], end=[0,500])</answer>',
+      });
+      const planner = createAutoGlmPlanner(false);
+      const result = await runCustomPlanning(
+        await prepareUserPrompt('swipe left'),
+        createPlanOptions({
+          context: { ...context, shotSize: { width: 101, height: 81 } },
+        }),
+        resolveCustomPlanningDefinition({
+          ...planner,
+          coordinates: { ...planner.coordinates, rounding },
+        }),
+      );
+      expect(result.actions).toMatchObject([
+        {
+          type: 'Scroll',
+          param: { locate: { locatedPixelResult: { center } }, distance },
+        },
+      ]);
+    },
+  );
+
   it('runs Auto-GLM custom planning and transforms tap coordinates', async () => {
     rs.mocked(callAIWithStringResponse).mockResolvedValueOnce({
       content:

--- a/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/deepseek.test.ts
@@ -58,11 +58,13 @@ describe('deepseek model adapter', () => {
       shape: 'point',
       order: 'yx',
       normalizedBy: 2000,
+      rounding: 'round',
     });
     const bboxPromptSpec = createLocateResultPromptSpec({
       shape: 'bbox',
       order: 'yx',
       normalizedBy: 2000,
+      rounding: 'round',
     });
     const elementInstructions =
       deepSeekElementLocateProtocol.buildResponseInstructions(pointPromptSpec);
@@ -97,7 +99,7 @@ describe('deepseek model adapter', () => {
       locateAdapter.element.resultCodec.toPixelResult(rawResult.target, {
         preparedSize: { width: 1000, height: 1000 },
       }),
-    ).toEqual({ center: [927, 779] });
+    ).toEqual({ center: [928, 780] });
   });
 
   it('uses ref-box tokens and bbox coordinates for deepLocate search area', () => {
@@ -157,7 +159,7 @@ describe('deepseek model adapter', () => {
     const context = { preparedSize: { width: 1000, height: 1000 } };
     expect(
       searchAreaResultCodec.toPixelResult(rawResult.target, context).rect,
-    ).toEqual({ left: 844, top: 390, width: 31, height: 41 });
+    ).toEqual({ left: 845, top: 390, width: 31, height: 41 });
     expect(
       rawResult.references?.map(
         (reference) =>
@@ -249,7 +251,7 @@ describe('deepseek model adapter', () => {
       locateAdapter.resultCodec.toPixelResult(rawResult.target, {
         preparedSize: { width: 1000, height: 1000 },
       }),
-    ).toEqual({ center: [927, 779] });
+    ).toEqual({ center: [928, 780] });
   });
 
   it('maps DeepSeek reasoning controls and provider defaults', () => {

--- a/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/default-locate-protocol.test.ts
@@ -22,6 +22,7 @@ describe('default locate protocol', () => {
       shape: 'bbox',
       order: 'xy',
       normalizedBy: 1000,
+      rounding: 'round',
     });
     const systemPrompt = buildElementLocateSystemPrompt({
       systemPromptIntroduction: elementProtocol.systemPromptIntroduction,
@@ -62,6 +63,7 @@ describe('default locate protocol', () => {
       shape: 'bbox',
       order: 'xy',
       normalizedBy: 1000,
+      rounding: 'round',
     });
 
     expect(
@@ -101,6 +103,7 @@ describe('default locate protocol', () => {
       shape: 'bbox',
       order: 'xy',
       normalizedBy: 1000,
+      rounding: 'round',
     });
 
     expect(() =>
@@ -137,6 +140,7 @@ describe('default locate protocol', () => {
       shape: 'bbox',
       order: 'xy',
       normalizedBy: 1000,
+      rounding: 'round',
     });
 
     expect(
@@ -168,6 +172,7 @@ describe('default locate protocol', () => {
       shape: 'bbox',
       order: 'xy',
       normalizedBy: 1000,
+      rounding: 'round',
     });
 
     expect(() =>

--- a/packages/core/tests/unit-test/model-adapter/doubao.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/doubao.test.ts
@@ -263,13 +263,18 @@ describe('doubao model adapter', () => {
       locateAdapter.element.resultCodec.toPixelResult('[336, 163, 717, 200]', {
         preparedSize: { width: 1000, height: 2000 },
       }).rect,
-    ).toEqual({ left: 336, top: 326, width: 381, height: 75 });
+    ).toEqual({ left: 336, top: 326, width: 382, height: 75 });
   });
 
   it('parses valid raw Doubao locate values directly', () => {
     expect(parseDoubaoRawLocateValue([100, 200, 300, 400])).toEqual({
       coordinates: [100, 200, 300, 400],
-      coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+      coordinatesMeta: {
+        shape: 'bbox',
+        order: 'xy',
+        normalizedBy: 1000,
+        rounding: 'round' as const,
+      },
     });
   });
 
@@ -279,7 +284,12 @@ describe('doubao model adapter', () => {
       input: '100 200 300 400',
       result: {
         coordinates: [100, 200, 300, 400],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -287,7 +297,12 @@ describe('doubao model adapter', () => {
       input: ['100', '200', '300', '400'],
       result: {
         coordinates: [100, 200, 300, 400],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -295,7 +310,12 @@ describe('doubao model adapter', () => {
       input: '100 200 300 400 ',
       result: {
         coordinates: [100, 200, 300, 400],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -303,7 +323,12 @@ describe('doubao model adapter', () => {
       input: '[336, 163, 717, 200]',
       result: {
         coordinates: [336, 163, 717, 200],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -311,7 +336,12 @@ describe('doubao model adapter', () => {
       input: '336,163,717,200',
       result: {
         coordinates: [336, 163, 717, 200],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -319,7 +349,12 @@ describe('doubao model adapter', () => {
       input: [653, '277; 664 291;'],
       result: {
         coordinates: [653, 277, 664, 291],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -327,7 +362,12 @@ describe('doubao model adapter', () => {
       input: [653, '277, 664, 291,'],
       result: {
         coordinates: [653, 277, 664, 291],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -335,7 +375,12 @@ describe('doubao model adapter', () => {
       input: ['bbox', [782, 541, 815, 559]],
       result: {
         coordinates: [782, 541, 815, 559],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -343,7 +388,12 @@ describe('doubao model adapter', () => {
       input: ['bbox', '782, 541, 815, 559'],
       result: {
         coordinates: [782, 541, 815, 559],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -351,7 +401,12 @@ describe('doubao model adapter', () => {
       input: [410, 295, 885, '345<', '/bbox>,\n  "error": ""\n}'],
       result: {
         coordinates: [410, 295, 885, 345],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -359,7 +414,12 @@ describe('doubao model adapter', () => {
       input: ['bbox_859_773_923_808'],
       result: {
         coordinates: [859, 773, 923, 808],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -367,7 +427,12 @@ describe('doubao model adapter', () => {
       input: 'bbox_859_773_923_808',
       result: {
         coordinates: [859, 773, 923, 808],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -375,7 +440,12 @@ describe('doubao model adapter', () => {
       input: ['bbox_2d', [650, 700, 710, 730]],
       result: {
         coordinates: [650, 700, 710, 730],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -383,7 +453,12 @@ describe('doubao model adapter', () => {
       input: ['-100', 200, 300, 400],
       result: {
         coordinates: [100, 200, 300, 400],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -391,7 +466,12 @@ describe('doubao model adapter', () => {
       input: ['100.5', 200, 300, 400],
       result: {
         coordinates: [100, 5, 200, 300],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -399,7 +479,12 @@ describe('doubao model adapter', () => {
       input: 'error: 500, 503; bbox_100_200_300_400',
       result: {
         coordinates: [100, 200, 300, 400],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -410,7 +495,12 @@ describe('doubao model adapter', () => {
       ],
       result: {
         coordinates: [100, 200, 300, 400],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -418,7 +508,12 @@ describe('doubao model adapter', () => {
       input: '100 200 300',
       result: {
         coordinates: [100, 200],
-        coordinatesMeta: { shape: 'point', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'point',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
     {
@@ -426,7 +521,12 @@ describe('doubao model adapter', () => {
       input: '1 2 3 4 5 6 7 8',
       result: {
         coordinates: [1, 2, 5, 6],
-        coordinatesMeta: { shape: 'bbox', order: 'xy', normalizedBy: 1000 },
+        coordinatesMeta: {
+          shape: 'bbox',
+          order: 'xy',
+          normalizedBy: 1000,
+          rounding: 'round' as const,
+        },
       },
     },
   ])('parses malformed raw Doubao locate value: $name', ({ input, result }) => {
@@ -498,7 +598,7 @@ describe('doubao model adapter', () => {
       ['123 100', '789 222'],
       { preparedSize: { width: 1000, height: 2000 } },
     ).rect;
-    expect(result).toEqual({ left: 123, top: 200, width: 666, height: 245 });
+    expect(result).toEqual({ left: 123, top: 200, width: 667, height: 245 });
   });
 
   it('normalizes doubao bbox with comma-separated point strings', () => {
@@ -512,7 +612,7 @@ describe('doubao model adapter', () => {
       ['123,100', '789, 222'],
       { preparedSize: { width: 1000, height: 2000 } },
     ).rect;
-    expect(result).toEqual({ left: 123, top: 200, width: 666, height: 245 });
+    expect(result).toEqual({ left: 123, top: 200, width: 667, height: 245 });
   });
 
   it('flattens single nested doubao bbox', () => {

--- a/packages/core/tests/unit-test/model-adapter/ui-tars/locate-result.test.ts
+++ b/packages/core/tests/unit-test/model-adapter/ui-tars/locate-result.test.ts
@@ -34,7 +34,7 @@ describe('ui-tars locate result codec', () => {
       locateResultCodec.toPixelResult(['123,100', '789 222'], {
         preparedSize: { width: 1000, height: 2000 },
       }).rect,
-    ).toEqual({ left: 123, top: 200, width: 666, height: 245 });
+    ).toEqual({ left: 123, top: 200, width: 667, height: 245 });
   });
 
   it('normalizes UI-TARS bbox arrays with numeric strings', () => {

--- a/packages/core/tests/unit-test/planning-tap-locator.test.ts
+++ b/packages/core/tests/unit-test/planning-tap-locator.test.ts
@@ -20,6 +20,7 @@ function createPlanner(): ResolvedCustomPlanningDefinition<null> {
       shape: 'point',
       order: 'xy',
       normalizedBy: 1000,
+      rounding: 'round',
     },
     coordinateNormalizer: {} as any,
     parseResponse: () => null,

--- a/packages/core/tests/unit-test/section-locate-protocol.test.ts
+++ b/packages/core/tests/unit-test/section-locate-protocol.test.ts
@@ -144,13 +144,18 @@ describe('section locate protocol', () => {
         return values.length === 4
           ? {
               coordinates: values as [number, number, number, number],
-              coordinatesMeta: { shape: 'bbox' as const, order: 'xy' as const },
+              coordinatesMeta: {
+                shape: 'bbox' as const,
+                order: 'xy' as const,
+                rounding: 'round' as const,
+              },
             }
           : {
               coordinates: values as [number, number],
               coordinatesMeta: {
                 shape: 'point' as const,
                 order: 'xy' as const,
+                rounding: 'round' as const,
               },
             };
       });


### PR DESCRIPTION
Normalized positions previously used `size - 1`, while action distances used the full image size. Use `value * size / normalizedBy` for both through the shared pixel mapper. For example, coordinate 999 on a 2000px image with a normalization range of 1000 now maps to 1998 instead of 1997; position bounds remain clamped separately.

Add `coordinates.rounding` with `round`, `trunc`, and `none` strategies. Resolve the default to `round` when resolving adapter coordinates, require an explicit strategy in parsed coordinate metadata, and configure existing adapters with `round`. Raw pixel inputs retain their precision. Tests cover rounding consistency across points, bbox metadata and distances, boundary clamping, parser metadata validation, and AutoGLM planning.

Validation:
- `pnpm run lint`
- `NX_DAEMON=false pnpm exec nx build @midscene/core`
- `NX_DAEMON=false pnpm exec nx test @midscene/core` — 1636 passed, 8 skipped.