### PR TITLE
test(web-integration): verify report screenshots on headless Linux

### DIFF
--- a/.github/workflows/report-screenshots-linux.yml
+++ b/.github/workflows/report-screenshots-linux.yml
@@ -1,0 +1,57 @@
+name: Report screenshots Linux
+
+on:
+  push:
+    branches: [fix/web-linux-report-screenshots-2970]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['1.10.3', workspace]
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+      MIDSCENE_REPORT_QUIET: 'true'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: '22.23.1'
+      - name: Prepare published baseline
+        if: matrix.version != 'workspace'
+        run: |
+          mkdir -p "$RUNNER_TEMP/report-screenshots"
+          cp packages/web-integration/tests/integration/report-screenshots.mjs "$RUNNER_TEMP/report-screenshots/"
+          cd "$RUNNER_TEMP/report-screenshots"
+          echo '{"private":true}' > package.json
+          pnpm add @midscene/web@1.10.3 @midscene/core@1.10.3 playwright@1.48.0
+          pnpm exec playwright install --with-deps chromium
+      - name: Prepare workspace
+        if: matrix.version == 'workspace'
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm exec nx run-many --target=build --projects=@midscene/web,@midscene/report
+          pnpm --filter @midscene/web exec playwright install --with-deps chromium
+      - name: Run published baseline
+        if: matrix.version != 'workspace'
+        working-directory: ${{ runner.temp }}/report-screenshots
+        run: node report-screenshots.mjs
+      - name: Run workspace regression
+        if: matrix.version == 'workspace'
+        working-directory: packages/web-integration
+        run: node tests/integration/report-screenshots.mjs
+      - name: Upload screenshots and reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: report-screenshots-${{ matrix.version }}
+          path: |
+            ${{ runner.temp }}/report-screenshots/midscene_run
+            packages/web-integration/midscene_run

--- a/.github/workflows/report-screenshots-linux.yml
+++ b/.github/workflows/report-screenshots-linux.yml
@@ -35,7 +35,7 @@ jobs:
           cp packages/web-integration/tests/integration/report-screenshots.mjs "$RUNNER_TEMP/report-screenshots/"
           cd "$RUNNER_TEMP/report-screenshots"
           echo '{"private":true}' > package.json
-          pnpm add @midscene/web@1.10.3 @midscene/core@1.10.3 playwright@1.48.0
+          pnpm add @midscene/web@1.10.3 @midscene/core@1.10.3 playwright@1.48.0 @playwright/test@1.48.0
           pnpm exec playwright install --with-deps chromium
       - name: Prepare workspace
         if: matrix.version == 'workspace'

--- a/.github/workflows/report-screenshots-linux.yml
+++ b/.github/workflows/report-screenshots-linux.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: report-screenshots-linux-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   screenshots:
     runs-on: ubuntu-22.04

--- a/.github/workflows/report-screenshots-linux.yml
+++ b/.github/workflows/report-screenshots-linux.yml
@@ -1,15 +1,23 @@
 name: Report screenshots Linux
 
 on:
-  push:
-    branches: [fix/web-linux-report-screenshots-2970]
+  pull_request:
+    paths:
+      - '.github/workflows/report-screenshots-linux.yml'
+      - 'packages/web-integration/src/**'
+      - 'packages/web-integration/tests/integration/report-screenshots.mjs'
+      - 'packages/web-integration/package.json'
+      - 'packages/core/**'
+      - 'packages/shared/src/img/**'
+      - 'packages/visualizer/**'
+      - 'apps/report/**'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: report-screenshots-linux-${{ github.ref }}
+  group: report-screenshots-linux-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -19,7 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.10.3', workspace]
+        # Manual runs also check the exact published environment from #2970.
+        version: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["1.10.3","workspace"]' || '["workspace"]') }}
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
       MIDSCENE_REPORT_QUIET: 'true'
@@ -50,7 +59,7 @@ jobs:
       - name: Run workspace regression
         if: matrix.version == 'workspace'
         working-directory: packages/web-integration
-        run: node tests/integration/report-screenshots.mjs
+        run: pnpm exec nx run @midscene/web:test:report-screenshots
       - name: Upload screenshots and reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -98,6 +98,7 @@
     "build:watch": "rslib build --watch --no-clean",
     "playground": "DEBUG=midscene:* tsx demo/playground.ts",
     "test": "rstest",
+    "test:report-screenshots": "node tests/integration/report-screenshots.mjs",
     "test:u": "rstest -u",
     "test:ai": "AI_TEST_TYPE=web rstest",
     "test:ai:cache": "MIDSCENE_CACHE=true AI_TEST_TYPE=web rstest",

--- a/packages/web-integration/tests/integration/report-screenshots.mjs
+++ b/packages/web-integration/tests/integration/report-screenshots.mjs
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
+import { platform, release } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parseDumpScript, parseImageScripts } from '@midscene/core';
@@ -18,10 +20,40 @@ form { position: absolute; left: 1100px; top: 240px; padding: 40px;
   width: 300px; background: white; border-radius: 20px; }
 input, button { box-sizing: border-box; display: block; width: 300px;
   height: 48px; margin: 16px 0; font-size: 20px; }
+#account { position: fixed; left: 1140px; top: 324px; }
 </style></head><body><form onsubmit="event.preventDefault()">
 <h1>Login</h1><input id="account" aria-label="Account" />
 <input type="password" aria-label="Password" /><button>Login</button>
 </form></body></html>`;
+async function measureImage(page, src) {
+  return page.evaluate(async (src) => {
+    const image = new Image();
+    image.src = src;
+    await image.decode();
+    const canvas = document.createElement('canvas');
+    canvas.width = 160;
+    canvas.height = 90;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(image, 0, 0, 160, 90);
+    const pixels = ctx.getImageData(0, 0, 160, 90).data;
+    let colored = 0;
+    for (let i = 0; i < pixels.length; i += 4) {
+      if (Math.max(pixels[i], pixels[i + 1], pixels[i + 2]) > 40) colored++;
+    }
+    return {
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+      nonBlackRatio: colored / (160 * 90),
+    };
+  }, src);
+}
+const require = createRequire(import.meta.url);
+const environment = {
+  os: `${platform()} ${release()}`,
+  node: process.version,
+  playwright: require('playwright/package.json').version,
+};
+console.log(JSON.stringify(environment));
 const artifactDir = resolve(
   process.env.SCREENSHOT_ARTIFACT_DIR || 'midscene_run/screenshot-regression',
 );
@@ -80,14 +112,6 @@ try {
           viewport: { width: 1600, height: 900 },
         });
         await page.setContent(fixture);
-        const inputBox = await page.locator('#account').boundingBox();
-        // Keep the target under the stub's fixed center even if fonts differ.
-        await page.locator('#account').evaluate((input) => {
-          input.style.position = 'fixed';
-          input.style.left = '1140px';
-          input.style.top = '324px';
-        });
-        assert(inputBox);
         inferenceImages = [];
         const agent = new PlaywrightAgent(page, {
           outputFormat,
@@ -154,27 +178,7 @@ try {
               join(artifactDir, `${name}-${kind}-${index}.jpeg`),
               Buffer.from(src.split(',')[1], 'base64'),
             );
-            const metric = await page.evaluate(async (src) => {
-              const image = new Image();
-              image.src = src;
-              await image.decode();
-              const canvas = document.createElement('canvas');
-              canvas.width = 160;
-              canvas.height = 90;
-              const ctx = canvas.getContext('2d');
-              ctx.drawImage(image, 0, 0, 160, 90);
-              const pixels = ctx.getImageData(0, 0, 160, 90).data;
-              let colored = 0;
-              for (let i = 0; i < pixels.length; i += 4) {
-                if (Math.max(pixels[i], pixels[i + 1], pixels[i + 2]) > 40)
-                  colored++;
-              }
-              return {
-                width: image.naturalWidth,
-                height: image.naturalHeight,
-                nonBlackRatio: colored / (160 * 90),
-              };
-            }, src);
+            const metric = await measureImage(page, src);
             metrics.push({ kind, index, ...metric });
             if (kind === 'report') {
               assert.equal(metric.width, 1600);
@@ -190,6 +194,8 @@ try {
           name,
           browser: browser.version(),
           reportFile: agent.reportFile,
+          sdkVersion: dump.sdkVersion,
+          environment,
           metrics,
         });
         await page.goto(pathToFileURL(agent.reportFile).href);
@@ -208,6 +214,18 @@ try {
             path: join(artifactDir, `${name}-viewer.png`),
           });
         }
+        const rendered = await page
+          .locator('.player-container .canvas-container')
+          .screenshot();
+        const renderedMetric = await measureImage(
+          page,
+          `data:image/png;base64,${rendered.toString('base64')}`,
+        );
+        metrics.push({ kind: 'viewer', ...renderedMetric });
+        assert(
+          renderedMetric.nonBlackRatio > 0.7,
+          `${name} viewer is black: ${JSON.stringify(renderedMetric)}`,
+        );
         console.log(JSON.stringify(results.at(-1)));
         await page.close();
       }

--- a/packages/web-integration/tests/integration/report-screenshots.mjs
+++ b/packages/web-integration/tests/integration/report-screenshots.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { dirname, join, resolve } from 'node:path';
+import { parseDumpScript, parseImageScripts } from '@midscene/core';
+import { PlaywrightAgent } from '@midscene/web/playwright';
+import { chromium } from 'playwright';
+
+// Exercise the real capture, action, persistence and viewer paths without an
+// external model. The model stub returns a known coordinate on this fixture.
+const fixture = `<!doctype html><html><head><style>
+html, body { margin: 0; width: 100%; height: 100%; }
+body { background: linear-gradient(120deg, #207bd1, #e36ac6, #30bc96);
+  background-size: 300% 300%; animation: gradient 2s infinite alternate; }
+@keyframes gradient { to { background-position: 100% 100%; } }
+form { position: absolute; left: 1100px; top: 240px; padding: 40px;
+  width: 300px; background: white; border-radius: 20px; }
+input, button { box-sizing: border-box; display: block; width: 300px;
+  height: 48px; margin: 16px 0; font-size: 20px; }
+</style></head><body><form onsubmit="event.preventDefault()">
+<h1>Login</h1><input id="account" aria-label="Account" />
+<input type="password" aria-label="Password" /><button>Login</button>
+</form></body></html>`;
+const artifactDir = resolve(
+  process.env.SCREENSHOT_ARTIFACT_DIR || 'midscene_run/screenshot-regression',
+);
+await mkdir(artifactDir, { recursive: true });
+let inferenceImages = [];
+const server = createServer(async (req, res) => {
+  try {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = JSON.parse(Buffer.concat(chunks).toString());
+    for (const message of body.messages) {
+      if (!Array.isArray(message.content)) continue;
+      for (const part of message.content) {
+        if (part.type === 'image_url') inferenceImages.push(part.image_url.url);
+      }
+    }
+    res.setHeader('Content-Type', 'application/json');
+    res.end(
+      JSON.stringify({
+        id: 'screenshot-regression',
+        object: 'chat.completion',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: JSON.stringify({
+                bbox: [1140, 340, 1440, 388],
+                errors: [],
+                pass: true,
+                thought: 'Deterministic screenshot plumbing fixture',
+              }),
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+    );
+  } catch (error) {
+    res.writeHead(500).end(String(error));
+  }
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const results = [];
+try {
+  for (const disableGpu of [false, true]) {
+    const browser = await chromium.launch({
+      headless: true,
+      args: ['--no-sandbox', ...(disableGpu ? ['--disable-gpu'] : [])],
+    });
+    try {
+      for (const outputFormat of ['single-html', 'html-and-external-assets']) {
+        const name = `${outputFormat}-${disableGpu ? 'disable-gpu' : 'default'}`;
+        const page = await browser.newPage({
+          viewport: { width: 1600, height: 900 },
+        });
+        await page.setContent(fixture);
+        const inputBox = await page.locator('#account').boundingBox();
+        // Keep the target under the stub's fixed center even if fonts differ.
+        await page.locator('#account').evaluate((input) => {
+          input.style.position = 'fixed';
+          input.style.left = '1140px';
+          input.style.top = '324px';
+        });
+        assert(inputBox);
+        inferenceImages = [];
+        const agent = new PlaywrightAgent(page, {
+          outputFormat,
+          reportFileName: name,
+          modelConfig: {
+            MIDSCENE_MODEL_NAME: 'screenshot-regression',
+            MIDSCENE_MODEL_FAMILY: 'qwen2.5-vl',
+            MIDSCENE_MODEL_API_KEY: 'local-stub',
+            MIDSCENE_MODEL_BASE_URL: `http://127.0.0.1:${server.address().port}/v1`,
+          },
+        });
+        try {
+          await agent.aiTap('Account input');
+          await page.keyboard.type('test');
+          assert.equal(await page.locator('#account').inputValue(), 'test');
+          await agent.aiAssert('The login form is visible');
+        } finally {
+          await agent.destroy();
+        }
+        assert(agent.reportFile, 'The agent must generate an HTML report');
+        const html = await readFile(agent.reportFile, 'utf8');
+        const dump = JSON.parse(parseDumpScript(html));
+        const inlineImages = Object.values(parseImageScripts(html));
+        const externalPaths = new Set();
+        const visit = (value) => {
+          if (!value || typeof value !== 'object') return;
+          if (
+            value.type === 'midscene_screenshot_ref' &&
+            value.storage === 'file'
+          )
+            externalPaths.add(value.path);
+          for (const child of Object.values(value)) visit(child);
+        };
+        visit(dump);
+        const reportImages = [...inlineImages];
+        for (const path of externalPaths) {
+          reportImages.push(
+            `data:image/jpeg;base64,${(await readFile(join(dirname(agent.reportFile), path))).toString('base64')}`,
+          );
+        }
+        assert(
+          inferenceImages.length > 0,
+          'The model must receive screenshots',
+        );
+        assert(reportImages.length > 0, 'The report must contain screenshots');
+        if (outputFormat === 'html-and-external-assets')
+          assert(externalPaths.size > 0, 'External assets must exist');
+        const metrics = [];
+        for (const [kind, images] of [
+          ['inference', inferenceImages],
+          ['report', reportImages],
+        ]) {
+          for (const [index, src] of images.entries()) {
+            await writeFile(
+              join(artifactDir, `${name}-${kind}-${index}.jpeg`),
+              Buffer.from(src.split(',')[1], 'base64'),
+            );
+            const metric = await page.evaluate(async (src) => {
+              const image = new Image();
+              image.src = src;
+              await image.decode();
+              const canvas = document.createElement('canvas');
+              canvas.width = 160;
+              canvas.height = 90;
+              const ctx = canvas.getContext('2d');
+              ctx.drawImage(image, 0, 0, 160, 90);
+              const pixels = ctx.getImageData(0, 0, 160, 90).data;
+              let colored = 0;
+              for (let i = 0; i < pixels.length; i += 4) {
+                if (Math.max(pixels[i], pixels[i + 1], pixels[i + 2]) > 40)
+                  colored++;
+              }
+              return {
+                width: image.naturalWidth,
+                height: image.naturalHeight,
+                nonBlackRatio: colored / (160 * 90),
+              };
+            }, src);
+            metrics.push({ kind, index, ...metric });
+            assert.equal(metric.width, 1600);
+            assert.equal(metric.height, 900);
+            assert(
+              metric.nonBlackRatio > 0.95,
+              `${name} ${kind} ${index} is black: ${JSON.stringify(metric)}`,
+            );
+          }
+        }
+        results.push({
+          name,
+          browser: browser.version(),
+          reportFile: agent.reportFile,
+          metrics,
+        });
+        console.log(JSON.stringify(results.at(-1)));
+        await page.close();
+      }
+    } finally {
+      await browser.close();
+    }
+  }
+} finally {
+  await writeFile(
+    join(artifactDir, 'results.json'),
+    JSON.stringify(results, null, 2),
+  );
+  server.closeAllConnections();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/packages/web-integration/tests/integration/report-screenshots.mjs
+++ b/packages/web-integration/tests/integration/report-screenshots.mjs
@@ -47,12 +47,11 @@ const server = createServer(async (req, res) => {
             index: 0,
             message: {
               role: 'assistant',
-              content: JSON.stringify({
-                bbox: [1140, 340, 1440, 388],
-                errors: [],
-                pass: true,
-                thought: 'Deterministic screenshot plumbing fixture',
-              }),
+              content: JSON.stringify(body.messages).includes(
+                'StatementIsTruthy',
+              )
+                ? '<observation>Deterministic screenshot plumbing fixture</observation><data-json>{"StatementIsTruthy":true}</data-json>'
+                : JSON.stringify({ bbox: [1140, 340, 1440, 388], errors: [] }),
             },
             finish_reason: 'stop',
           },
@@ -70,6 +69,7 @@ try {
   for (const disableGpu of [false, true]) {
     const browser = await chromium.launch({
       headless: true,
+      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
       args: ['--no-sandbox', ...(disableGpu ? ['--disable-gpu'] : [])],
     });
     try {
@@ -166,8 +166,10 @@ try {
               };
             }, src);
             metrics.push({ kind, index, ...metric });
-            assert.equal(metric.width, 1600);
-            assert.equal(metric.height, 900);
+            if (kind === 'report') {
+              assert.equal(metric.width, 1600);
+              assert.equal(metric.height, 900);
+            }
             assert(
               metric.nonBlackRatio > 0.95,
               `${name} ${kind} ${index} is black: ${JSON.stringify(metric)}`,

--- a/packages/web-integration/tests/integration/report-screenshots.mjs
+++ b/packages/web-integration/tests/integration/report-screenshots.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { parseDumpScript, parseImageScripts } from '@midscene/core';
 import { PlaywrightAgent } from '@midscene/web/playwright';
 import { chromium } from 'playwright';
@@ -109,10 +110,16 @@ try {
         assert(agent.reportFile, 'The agent must generate an HTML report');
         const html = await readFile(agent.reportFile, 'utf8');
         const dump = JSON.parse(parseDumpScript(html));
-        const inlineImages = Object.values(parseImageScripts(html));
+        const inlineImages = parseImageScripts(html);
+        const inlineIds = new Set();
         const externalPaths = new Set();
         const visit = (value) => {
           if (!value || typeof value !== 'object') return;
+          if (
+            value.type === 'midscene_screenshot_ref' &&
+            value.storage === 'inline'
+          )
+            inlineIds.add(value.id);
           if (
             value.type === 'midscene_screenshot_ref' &&
             value.storage === 'file'
@@ -121,7 +128,10 @@ try {
           for (const child of Object.values(value)) visit(child);
         };
         visit(dump);
-        const reportImages = [...inlineImages];
+        const reportImages = [...inlineIds].map((id) => {
+          assert(inlineImages[id], `Missing inline screenshot: ${id}`);
+          return inlineImages[id];
+        });
         for (const path of externalPaths) {
           reportImages.push(
             `data:image/jpeg;base64,${(await readFile(join(dirname(agent.reportFile), path))).toString('base64')}`,
@@ -182,6 +192,22 @@ try {
           reportFile: agent.reportFile,
           metrics,
         });
+        await page.goto(pathToFileURL(agent.reportFile).href);
+        try {
+          await page
+            .locator('.player-container img')
+            .first()
+            .waitFor({ state: 'visible', timeout: 20_000 });
+          await page.waitForFunction(() =>
+            [...document.querySelectorAll('.player-container img')].some(
+              (img) => img.complete && img.naturalWidth > 0,
+            ),
+          );
+        } finally {
+          await page.screenshot({
+            path: join(artifactDir, `${name}-viewer.png`),
+          });
+        }
         console.log(JSON.stringify(results.at(-1)));
         await page.close();
       }


### PR DESCRIPTION
Investigates #2970: reports were described as black on headless Ubuntu while AI actions succeeded. This adds a Linux integration test that exercises PlaywrightAgent.aiTap/aiAssert with a local model stub, checks the actual model-input and persisted image pixels, opens the generated HTML report, and checks the rendered player pixels. Both single-html and external assets are covered with default Chromium flags and --disable-gpu. Reports, extracted images, viewer screenshots, and environment/pixel metrics are uploaded as artifacts.

Ubuntu 22.04 CI passed all eight combinations for published Midscene 1.10.3 / Playwright 1.48.0 and workspace 1.12.5 / Playwright 1.58.1 on Node 22.23.1: https://github.com/web-infra-dev/midscene/actions/runs/34184700948. The published baseline uses Chromium 130; workspace uses its pinned Playwright Chromium. PR runs check workspace; manual runs also check the published baseline.

This does not claim to fix or close #2970: the animated-gradient fixture did not reproduce black screenshots. A failing report or the original page is still needed to identify the cause. The model is stubbed to isolate screenshot/report plumbing; this is not a real-model validation. Inspection also confirms MIDSCENE_OUTPUT_FORMAT is not read by the SDK; outputFormat must be passed to the Agent to select external assets.

Validation:
- `pnpm run lint`
- `pnpm exec nx run-many --target=build --projects=@midscene/web,@midscene/report`
- `pnpm exec nx test @midscene/web -- tests/unit-test/base-page-screenshot.test.ts` (4 passed)
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm exec nx run @midscene/web:test:report-screenshots` (4 combinations passed locally)
- `node report-screenshots.mjs` (published baseline on Ubuntu 22.04, 4 combinations passed)
- `node tests/integration/report-screenshots.mjs` (workspace on Ubuntu 22.04, 4 combinations passed)
