### PR TITLE
chore(test): add model configuration template to .env.example and update README; adjust create command tests

### DIFF
--- a/packages/test/src/cli/create-template.ts
+++ b/packages/test/src/cli/create-template.ts
@@ -102,6 +102,18 @@ const platformEnv: Record<CreatePlatform, string> = {
     '# Optional: select a display; leave empty for the default display.\nCOMPUTER_DISPLAY_ID=\n# Enable Xvfb on headless Linux after installing its dependencies.\nMIDSCENE_COMPUTER_HEADLESS_LINUX=false\n',
 };
 
+const modelEnv = `# Copy this file to .env before running tests.
+# Do not commit .env to your repository. In CI, inject these values as environment variables instead.
+# Choose a supported model and copy its four configuration values from:
+# https://midscenejs.com/model-common-config.html
+# For the complete environment variable reference, see:
+# https://midscenejs.com/model-config.html
+MIDSCENE_MODEL_BASE_URL=
+MIDSCENE_MODEL_API_KEY=
+MIDSCENE_MODEL_NAME=
+MIDSCENE_MODEL_FAMILY=
+`;
+
 const platformInstructions: Record<Exclude<CreatePlatform, 'web'>, string> = {
   android:
     'Connect an Android device and verify it with `adb devices`. Set ANDROID_DEVICE_ID to select a device.',
@@ -233,8 +245,8 @@ ${extraNodes}
         : platform === 'computer'
           ? 'cases:\n  - name: Inspect the desktop\n    steps:\n      - aiAsk: Describe the current desktop\n'
           : 'cases:\n  - name: Inspect the home screen\n    steps:\n      - home: {}\n      - aiAsk: Describe the current screen\n',
-    '.env.example': `# Copy this file to .env and configure your model before running tests.\n# See https://midscenejs.com/model-config.html\nMIDSCENE_MODEL_BASE_URL=\nMIDSCENE_MODEL_API_KEY=\nMIDSCENE_MODEL_NAME=\nMIDSCENE_MODEL_FAMILY=\n\n${env}`,
+    '.env.example': `${modelEnv}\n${env}`,
     '.gitignore': 'node_modules/\n.env\nmidscene_run/\n',
-    'README.md': `# ${name}\n\nA Midscene Test project for ${platform}.\n\nIf you skipped installation during creation, run \`${packageManager} ${packageManagerCommands[packageManager].install.join(' ')}\`. The \`postinstall\` script automatically generates \`midscene-node-reference.md\` after each dependency installation. If lifecycle scripts are disabled, run \`${packageManager} run nodes\` manually.\n\nCopy \`.env.example\` to \`.env\` and fill in your [model configuration](https://midscenejs.com/model-config.html).\n\n${instructions}\n\nRun tests with \`${packageManager} test\`. Read \`midscene-node-reference.md\` for the available Nodes and their inputs.\n\nAfter changing Node registrations in \`midscene.config.ts\`, run \`${packageManager} run nodes\` to refresh the reference. This loads the configuration without connecting to a device or running tests. Extension factories must only acquire runtime resources inside Node execution.\n\n${packages.length ? `Node packages: ${packages.map((pkg) => `\`${pkg.name}\``).join(', ')}. Their \`createMidsceneTestNodes\` factories are imported in the configuration.\n\n` : ''}Reports are written to \`midscene_run/report/\`.\n`,
+    'README.md': `# ${name}\n\nA Midscene Test project for ${platform}.\n\nIf you skipped installation during creation, run \`${packageManager} ${packageManagerCommands[packageManager].install.join(' ')}\`. The \`postinstall\` script automatically generates \`midscene-node-reference.md\` after each dependency installation. If lifecycle scripts are disabled, run \`${packageManager} run nodes\` manually.\n\nCopy \`.env.example\` to \`.env\`, then choose and configure a model using the [supported models and setup guide](https://midscenejs.com/model-common-config.html). Do not commit \`.env\` to your repository; inject the model configuration as environment variables in CI.\n\n${instructions}\n\nRun tests with \`${packageManager} test\`. Read \`midscene-node-reference.md\` for the available Nodes and their inputs.\n\nAfter changing Node registrations in \`midscene.config.ts\`, run \`${packageManager} run nodes\` to refresh the reference. This loads the configuration without connecting to a device or running tests. Extension factories must only acquire runtime resources inside Node execution.\n\n${packages.length ? `Node packages: ${packages.map((pkg) => `\`${pkg.name}\``).join(', ')}. Their \`createMidsceneTestNodes\` factories are imported in the configuration.\n\n` : ''}Reports are written to \`midscene_run/report/\`.\n`,
   };
 }

--- a/packages/test/tests/create-command.test.ts
+++ b/packages/test/tests/create-command.test.ts
@@ -419,7 +419,24 @@ describe('create project', () => {
     expect(config).toContain('from "@acme/nodes"');
     expect(config).not.toContain('@acme/nodes@1.2.0');
     expect(existsSync(join(root, '.env'))).toBe(false);
-    expect(existsSync(join(root, 'README.md'))).toBe(true);
+    const exampleEnv = readFileSync(join(root, '.env.example'), 'utf8');
+    expect(exampleEnv).toContain(
+      'https://midscenejs.com/model-common-config.html',
+    );
+    expect(exampleEnv).toContain('https://midscenejs.com/model-config.html');
+    expect(exampleEnv).toContain('MIDSCENE_MODEL_BASE_URL=');
+    expect(exampleEnv).toContain('MIDSCENE_MODEL_API_KEY=');
+    expect(exampleEnv).toContain('MIDSCENE_MODEL_NAME=');
+    expect(exampleEnv).toContain('MIDSCENE_MODEL_FAMILY=');
+    expect(exampleEnv).toContain('Do not commit .env to your repository');
+    expect(exampleEnv).toContain(
+      'In CI, inject these values as environment variables instead',
+    );
+    const readme = readFileSync(join(root, 'README.md'), 'utf8');
+    expect(readme).toContain('Do not commit `.env` to your repository');
+    expect(readme).toContain(
+      'inject the model configuration as environment variables in CI',
+    );
     expect(existsSync(join(root, 'README.zh.md'))).toBe(false);
   });
 


### PR DESCRIPTION
### Motivation

- Provide a clear, copy-pasteable template for model configuration and stronger guidance to avoid committing secrets to repo.
- Point users to the supported model configuration documentation and clarify CI practices for injecting model credentials.

### Description

- Add a `modelEnv` template string containing `MIDSCENE_MODEL_*` variables and explanatory comments and prepend it to the generated `.env.example` file.
- Update `README.md` content for new guidance to copy `.env.example` to `.env`, choose a supported model via the provided documentation link, and avoid committing `.env` by injecting model configuration in CI.
- Update the project creation generator to include the model template and adjust text links to `model-common-config.html` and `model-config.html`.
- Update `packages/test/tests/create-command.test.ts` to assert the presence of the new model variables, links, and README warnings in generated project files.

### Testing

- Ran the unit test suite for the test package including `create-command.test.ts`. All tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9f8383034083248471d8604d91cf65)