### PR TITLE
fix(core): collect streaming usage through stream completion

### DIFF
--- a/packages/core/src/ai-model/service-caller/index.ts
+++ b/packages/core/src/ai-model/service-caller/index.ts
@@ -639,6 +639,12 @@ export async function callAI(
             messages: messagesWithImageDetail,
             ...requestConfig,
             stream: true,
+            stream_options: {
+              ...(requestConfig.stream_options as
+                | Record<string, unknown>
+                | undefined),
+              include_usage: true,
+            },
           },
           {
             stream: true,
@@ -690,48 +696,30 @@ export async function callAI(
             };
             options.onChunk!(chunkData);
           }
-
-          // Check if stream is complete
-          if (chunk.choices?.[0]?.finish_reason) {
-            timeCost = Date.now() - startTime;
-
-            // If usage is not available from the stream, provide a basic usage info
-            if (!usage) {
-              // Estimate token counts based on content length (rough approximation)
-              const estimatedTokens = Math.max(
-                1,
-                Math.floor(accumulated.length / 4),
-              );
-              usage = {
-                prompt_tokens: estimatedTokens,
-                completion_tokens: estimatedTokens,
-                total_tokens: estimatedTokens * 2,
-              };
-            }
-
-            const finalAccumulated = resolveContentWithReasoningFallback(
-              accumulated,
-              accumulatedReasoning,
-            );
-            accumulated = finalAccumulated || '';
-
-            // Send final chunk
-            const finalUsage = buildUsageInfo(usage, requestId);
-            if (finalUsage && modelRuntime.onUsage) {
-              modelRuntime.onUsage(finalUsage);
-              usageReported = true;
-            }
-            const finalChunk: CodeGenerationChunk = {
-              content: '',
-              accumulated,
-              reasoning_content: '',
-              isComplete: true,
-              usage: finalUsage,
-            };
-            options.onChunk!(finalChunk);
-            break;
-          }
         }
+
+        timeCost = Date.now() - startTime;
+
+        const finalAccumulated = resolveContentWithReasoningFallback(
+          accumulated,
+          accumulatedReasoning,
+        );
+        accumulated = finalAccumulated || '';
+
+        // Send final chunk
+        const finalUsage = buildUsageInfo(usage, requestId);
+        if (finalUsage && modelRuntime.onUsage) {
+          modelRuntime.onUsage(finalUsage);
+          usageReported = true;
+        }
+        const finalChunk: CodeGenerationChunk = {
+          content: '',
+          accumulated,
+          reasoning_content: '',
+          isComplete: true,
+          usage: finalUsage,
+        };
+        options.onChunk!(finalChunk);
       } catch (error) {
         throw restoreHardTimeoutError(toError(error), streamSignal);
       } finally {
@@ -851,20 +839,6 @@ export async function callAI(
 
     debugCall(`response reasoning content: ${accumulatedReasoning}`);
     debugCall(`response content: ${content}`);
-
-    // Ensure we always have usage info for streaming responses
-    if (isStreaming && !usage) {
-      // Estimate token counts based on content length (rough approximation)
-      const estimatedTokens = Math.max(
-        1,
-        Math.floor((content || '').length / 4),
-      );
-      usage = {
-        prompt_tokens: estimatedTokens,
-        completion_tokens: estimatedTokens,
-        total_tokens: estimatedTokens * 2,
-      } as OpenAI.CompletionUsage;
-    }
 
     const finalUsage = buildUsageInfo(usage, requestId);
     // Report usage to the runtime-level collector if not already reported

--- a/packages/core/tests/unit-test/service-caller-streaming.test.ts
+++ b/packages/core/tests/unit-test/service-caller-streaming.test.ts
@@ -1,0 +1,122 @@
+import { getModelRuntime } from '@/ai-model/models';
+import { callAI } from '@/ai-model/service-caller';
+import type { CodeGenerationChunk } from '@/types';
+import type { IModelConfig } from '@midscene/shared/env';
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+
+const mockCreate = rs.fn();
+rs.mock('openai', () => ({
+  default: rs.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+  })),
+}));
+
+const modelConfig: IModelConfig = {
+  modelName: 'gpt-5.4',
+  modelFamily: 'gpt-5',
+  modelDescription: 'test',
+  openaiApiKey: 'test-key',
+  openaiBaseURL: 'https://example.com/v1',
+  intent: 'default',
+  slot: 'default',
+};
+const messages = [{ role: 'user' as const, content: 'Hello' }];
+const usage = { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 };
+
+const contentChunk = {
+  choices: [{ delta: { content: 'Hello' }, finish_reason: null }],
+};
+const finishChunk = {
+  choices: [{ delta: {}, finish_reason: 'stop' }],
+};
+
+describe('service-caller streaming usage', () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it('reads usage after finish_reason and completes only after the stream ends', async () => {
+    const events: string[] = [];
+    mockCreate.mockResolvedValue(
+      (async function* () {
+        yield contentChunk;
+        yield finishChunk;
+        yield { choices: [], usage };
+        events.push('stream-end');
+      })(),
+    );
+    const runtime = getModelRuntime({
+      ...modelConfig,
+      extraBody: {
+        stream_options: { include_usage: false, include_obfuscation: false },
+      },
+    });
+    const onUsage = rs.fn(() => events.push('usage'));
+    runtime.onUsage = onUsage;
+    const chunks: CodeGenerationChunk[] = [];
+    const result = await callAI(messages, runtime, {
+      stream: true,
+      onChunk: (chunk) => {
+        chunks.push(chunk);
+        if (chunk.isComplete) events.push('complete');
+      },
+    });
+    expect(mockCreate.mock.calls[0][0].stream_options).toEqual({
+      include_usage: true,
+      include_obfuscation: false,
+    });
+    expect(events).toEqual(['stream-end', 'usage', 'complete']);
+    expect(onUsage).toHaveBeenCalledTimes(1);
+    expect(result.usage).toMatchObject(usage);
+    expect(chunks.filter((chunk) => chunk.isComplete)).toHaveLength(1);
+    expect(chunks.at(-1)).toMatchObject({
+      accumulated: 'Hello',
+      usage,
+      isComplete: true,
+    });
+  });
+
+  it.each([true, false])(
+    'does not estimate missing usage (finish_reason present: %s)',
+    async (withFinish) => {
+      mockCreate.mockResolvedValue(
+        (async function* () {
+          yield contentChunk;
+          if (withFinish) yield finishChunk;
+        })(),
+      );
+      const runtime = getModelRuntime(modelConfig);
+      const onUsage = rs.fn();
+      runtime.onUsage = onUsage;
+      const onChunk = rs.fn();
+      const result = await callAI(messages, runtime, { stream: true, onChunk });
+      expect(mockCreate.mock.calls[0][0].stream_options).toEqual({
+        include_usage: true,
+      });
+      expect(result.content).toBe('Hello');
+      expect(result.usage).toBeUndefined();
+      expect(onUsage).not.toHaveBeenCalled();
+      expect(onChunk.mock.calls.at(-1)?.[0]).toMatchObject({
+        isComplete: true,
+        usage: undefined,
+      });
+    },
+  );
+
+  it('propagates a stream error after finish_reason without sending completion', async () => {
+    mockCreate.mockResolvedValue(
+      (async function* () {
+        yield contentChunk;
+        yield finishChunk;
+        throw new Error('stream interrupted');
+      })(),
+    );
+    const runtime = getModelRuntime(modelConfig);
+    const onUsage = rs.fn();
+    runtime.onUsage = onUsage;
+    const onChunk = rs.fn();
+    await expect(
+      callAI(messages, runtime, { stream: true, onChunk }),
+    ).rejects.toThrow('stream interrupted');
+    expect(onChunk.mock.calls.some(([chunk]) => chunk.isComplete)).toBe(false);
+    expect(onUsage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Streaming Chat Completions did not request usage by default and stopped reading at `finish_reason`, missing the separate usage chunk that can follow it. Missing usage was then replaced with token estimates derived from output length, including an unsupported estimate of input tokens.

- Set `stream_options.include_usage: true`, retaining other stream options.
- Consume the stream to its normal end before reporting usage and sending the final completion callback. Incremental content callbacks continue as chunks arrive.
- Remove both token-estimation fallbacks. If usage is absent, leave it undefined and do not report fabricated usage.
- Add tests for a trailing usage chunk, missing usage with/without `finish_reason`, preservation of other stream options, and an error after `finish_reason`.

This branch starts from main and contains only the usage fix, separate from the service-caller refactor in #3116.

## Validation

Passed:

```sh
pnpm run lint --vcs-enabled=true --staged
pnpm exec nx build @midscene/core
pnpm exec nx test @midscene/core -- tests/unit-test/service-caller-streaming.test.ts tests/unit-test/service-caller-timeout.test.ts tests/unit-test/service-caller-reasoning-fallback.test.ts tests/unit-test/service-caller-empty-content.test.ts
```

Live-model AI tests were not run. Providers that do not support `stream_options.include_usage` may reject the request.