### PR TITLE
docs(site): fix reference callout boundary and section headings

### DIFF
--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -1601,7 +1601,7 @@ The effective user context is `options.context ?? aiContexts[apiName] ?? aiConte
 
 Supported API keys are `aiAct`, `aiTap`, `aiRightClick`, `aiDoubleClick`, `aiHover`, `aiInput`, `aiKeyboardPress`, `aiScroll`, `aiPinch`, `aiLongPress`, `aiClearInput`, `aiLocate`, `aiQuery`, `aiBoolean`, `aiNumber`, `aiString`, `aiAsk`, `aiAssert`, and `aiWaitFor`. The `ai` and deprecated `aiAction` aliases use the `aiAct` context.
 
-### Shared types {#shared-types}
+## Shared types {#shared-types}
 
 <a id="deep-locate-deeplocate"></a>
 
@@ -1634,7 +1634,7 @@ To separate these two meanings, `deepThink` has been reserved for planning mode 
 
 <a id="prompting-with-images"></a>
 
-**Prompt input with images**
+## Prompt input with images
 
 Include reference images when text alone cannot identify the target clearly.
 
@@ -1705,7 +1705,7 @@ Follow your model provider's image size and dimension limits. Oversized or very 
 
 <a id="report-merging-tool"></a>
 
-### Report utilities {#reporting-utilities}
+## Report utilities {#reporting-utilities}
 
 Each automation workflow can generate its own report. `ReportMergingTool`
 combines those reports into one report so you can review all workflows

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -1571,7 +1571,7 @@ const isOnSale = await agent.aiBoolean('这个商品是否正在促销？');
 
 <a id="深度定位deeplocate"></a>
 
-### 共享类型 {#shared-types}
+## 共享类型 {#shared-types}
 
 **定位选项：深度定位（`deepLocate`）**
 
@@ -1597,13 +1597,14 @@ await agent.aiTap('右上角购物车图标', { deepLocate: true });
 
 - 对于 `aiAct()`，可以同时使用 `deepThink` 和 `deepLocate`：`deepThink` 控制规划模式，`deepLocate` 控制本节描述的深度定位。
 - 对于 `aiTap`、`aiHover` 等单步操作方法，如果需要提升定位精确度，推荐使用语义更清晰的 `deepLocate` 参数；旧的 `deepThink` 参数仍然兼容，语义等同于 `deepLocate`。
+
 :::
 
 <a id="prompting-with-images"></a>
 <a id="使用图片作为提示词"></a>
 <a id="通过图像提示"></a>
 
-**使用图片的提示词输入**
+## 使用图片的提示词输入
 
 你可以在提示词中使用图片作为补充，来描述无法通过自然语言表达的内容。
 
@@ -1671,7 +1672,7 @@ await agent.aiAct({
 
 请遵守模型提供商对图片体积和尺寸的限制。过大或过小的图片都可能被拒绝，准确限制请以模型提供商的文档为准。
 
-### 报告工具 {#reporting-utilities}
+## 报告工具 {#reporting-utilities}
 
 **`ReportMergingTool`**
 


### PR DESCRIPTION
The Chinese API reference's deepLocate Note closing marker immediately followed a list item, causing Rspress to include subsequent sections in the callout. Add the missing blank line so the Note ends before image prompting.

Promote image prompt input to a section heading and align the shared types and report utilities sections in both English and Chinese.

Validation:
- `pnpm run lint`
- `git diff --cached --check`
- Ran an inline Node script using the installed Rspress callout transformer and remark parser: subsequent headings inside the Chinese Note decreased from 9 to 0; the English Note already parsed correctly.
- Commit hook: `npx prettier --write` on both changed MDX files.