### PR TITLE
fix(computer): improve modifier-key input compatibility in desktop clients

### DIFF
--- a/apps/site/docs/en/faq.md
+++ b/apps/site/docs/en/faq.md
@@ -13,6 +13,87 @@ The following platform-specific FAQs are maintained in their respective document
 - [HarmonyOS](./platforms/harmonyos#faq)
 - [PC Desktop](./platforms/desktop#faq)
 
+## Why are uppercase letters or modifier keys lost when controlling desktop clients such as VNC? {#keyboard-input-through-desktop-clients}
+
+When you use `@midscene/computer` to control VNC, TeamViewer, or a virtual machine console, some clients may not recognize every keyboard event. For example, uppercase `K` may become `k`, `!` may become `1`, or `Control+S` may produce only `s`.
+
+If this happens, add a delay between modifier-key events. The following configuration has been verified with a full-screen VNC client on Windows.
+
+```typescript
+import { agentForComputer } from '@midscene/computer';
+
+const agent = await agentForComputer({
+  inputStrategy: 'sequential',
+  keyboardTypeDelay: 120,
+  keyboardModifierDelay: 100,
+  keyboardLayout: 'en-US',
+});
+```
+
+`keyboardModifierDelay` is the primary option for fixing lost modifiers. Start with `100`. After keyboard input works correctly, reduce the value gradually if needed.
+
+### Why does adding a delay help?
+
+Uppercase letters, shifted symbols, and keyboard shortcuts all depend on modifier keys.
+
+For example:
+
+- Uppercase `K` requires `Shift`, followed by `K`.
+- On an en-US keyboard, `!` requires `Shift`, followed by `1`.
+- `Control+S` requires `Control`, followed by `S`.
+
+Midscene converts these operations into modifier-down, primary-key, and key-release events.
+
+Some desktop clients capture these events and forward them to another system or feature. If the events arrive too close together, the client may not retain the modifier state while handling the primary key. The result can be a lowercase letter, a number instead of a symbol, or a shortcut reduced to its primary key.
+
+When you set `keyboardModifierDelay`, Midscene sends these events in phases and waits between each phase. This gives the desktop client time to recognize and forward the modifier state.
+
+Full-screen VNC is one verified example. However, this behavior is not limited to VNC or remote-control software. Any desktop client that captures or forwards keyboard events can be affected by input timing.
+
+### What does each option do?
+
+- `keyboardModifierDelay` controls the wait between phases of a modified-key input. It applies to shortcuts such as `Control+S` and to the implicit `Shift` in uppercase letters.
+- `keyboardTypeDelay` controls the wait between consecutive text characters.
+- `inputStrategy: 'sequential'` enters text one character at a time, allowing Midscene to send the corresponding key sequence for uppercase letters and shifted symbols.
+- `keyboardLayout: 'en-US'` enables shifted-character mapping for the en-US keyboard layout. For example, it uses `Shift+1` to enter `!`.
+
+Uppercase Latin letters do not require `keyboardLayout`. Only layout-dependent shifted characters such as `!`, `@`, and `#` require this option.
+
+:::warning
+Set `keyboardLayout: 'en-US'` only when both the local and target environments use the en-US key mapping. Other layouts may place symbols on different keys or require modifiers such as AltGr.
+:::
+
+### Which input methods support this option?
+
+`keyboardModifierDelay` applies only to the local libnut keyboard driver.
+
+- Local desktop control on Windows and Linux uses libnut.
+- macOS uses this path when you set `keyboardDriver: 'libnut'`.
+- The option has no effect on direct RDP input.
+- The option has no effect on the default macOS AppleScript keyboard driver.
+
+AppleScript uses a different input method. Whether a desktop client recognizes it still depends on the client's shortcut interception, keyboard mode, and layout conversion.
+
+### How do I send keyboard shortcuts?
+
+Pass the shortcut through the `keyName` option. Join modifiers and the primary key with `+`, without surrounding spaces.
+
+```typescript
+// Send Control+S to the element that already has focus.
+await agent.aiKeyboardPress(undefined, {
+  keyName: 'Control+S',
+});
+
+// Locate the terminal first, then send Control+Shift+P.
+await agent.aiKeyboardPress('the terminal window', {
+  keyName: 'Control+Shift+P',
+});
+```
+
+Use `Control+S`, not `Control + S`.
+
+When the target already has focus, pass `undefined` as the first argument. This prevents an additional click from changing the current selection or caret position.
+
 ## What data is sent to AI model?
 
 The screenshot will be sent to the AI model. In some cases, like setting the `domIncluded` option to `true` when calling `aiAsk` or `aiQuery`, the DOM information will also be sent.

--- a/apps/site/docs/en/reference/index.mdx
+++ b/apps/site/docs/en/reference/index.mdx
@@ -2929,6 +2929,8 @@ interface LocalComputerAgentOpt extends BaseComputerAgentOpt {
   // Local desktop options
   displayId?: string;
   keyboardDriver?: 'applescript' | 'libnut';
+  keyboardModifierDelay?: number;
+  keyboardLayout?: 'en-US';
   headless?: boolean;
   xvfbResolution?: string;
 }
@@ -2953,6 +2955,8 @@ interface RDPComputerAgentOpt extends BaseComputerAgentOpt {
 - `displayId?: string` — Display to control. Use `ComputerDevice.listDisplays()` to list the available displays. Default: the primary display.
 - `customActions?: DeviceAction<any>[]` — Add additional custom actions so the Agent can call your domain-specific actions.
 - `keyboardDriver?: 'applescript' | 'libnut'` — On macOS, keyboard event backend. Use `'applescript'` for the default, more compatible behavior or `'libnut'` for faster input when the target application supports it. Default: `'applescript'`.
+- `keyboardModifierDelay?: number` — Finite non-negative delay in milliseconds after each modifier transition and the primary key for the local libnut keyboard driver. It applies to shortcuts and to the implicit `Shift` used by uppercase letters during sequential text input. With `keyboardLayout: 'en-US'`, it also applies to shifted en-US punctuation. Default: `0`. This option has no effect on direct RDP input or the macOS AppleScript driver. See [Forward keyboard input through desktop clients](../faq#keyboard-input-through-desktop-clients).
+- `keyboardLayout?: 'en-US'` — Enables layout-dependent base-key mapping for shifted punctuation during sequential local libnut input. Uppercase Latin letters do not require it. Other layouts keep the backend's existing input behavior. This option has no effect on direct RDP input or the macOS AppleScript driver.
 - `headless?: boolean` — On Linux, set this to `true` to start a virtual display with [Xvfb](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml). This enables desktop automation on headless servers and in CI environments. You can also set the `MIDSCENE_COMPUTER_HEADLESS_LINUX=true` environment variable. Default: `false`.
 - `xvfbResolution?: string` — Resolution of the Xvfb virtual display. Default: `'1920x1080x24'`.
 

--- a/apps/site/docs/zh/faq.md
+++ b/apps/site/docs/zh/faq.md
@@ -13,6 +13,87 @@
 - [HarmonyOS](./platforms/harmonyos#常见问题)
 - [PC 桌面](./platforms/desktop#常见问题)
 
+## 操作 VNC 等桌面客户端时，为什么会丢失大写字母或修饰键？ {#keyboard-input-through-desktop-clients}
+
+使用 `@midscene/computer` 操作 VNC、TeamViewer 或虚拟机控制台时，部分客户端可能无法完整识别键盘事件。常见现象包括：大写 `K` 变成 `k`、`!` 变成 `1`，或者 `Control+S` 只输入了 `s`。
+
+遇到这些问题时，可以增加修饰键事件的间隔。下面是一组已经在 Windows VNC 全屏模式下验证过的配置。
+
+```typescript
+import { agentForComputer } from '@midscene/computer';
+
+const agent = await agentForComputer({
+  inputStrategy: 'sequential',
+  keyboardTypeDelay: 120,
+  keyboardModifierDelay: 100,
+  keyboardLayout: 'en-US',
+});
+```
+
+其中，`keyboardModifierDelay` 是解决修饰键丢失问题的主要配置。建议从 `100` 开始测试。确认输入正常后，可以逐步减小这个数值。
+
+### 为什么增加间隔可以解决问题？
+
+大写字母、特殊字符和组合键都依赖修饰键。
+
+例如：
+
+- 大写 `K` 需要按下 `Shift`，再按下 `K`。
+- en-US 键盘布局中的 `!` 需要按下 `Shift`，再按下 `1`。
+- `Control+S` 需要按下 `Control`，再按下 `S`。
+
+Midscene 会把这些操作转换成修饰键按下、主键按下和按键释放等事件。
+
+某些桌面客户端会捕获这些事件，并转发给另一个系统或功能模块。如果事件之间的间隔太短，客户端可能无法在处理主键时保留修饰键状态。结果就是大写字母变成小写、特殊字符变成数字，或者组合键只剩下主键。
+
+设置 `keyboardModifierDelay` 后，Midscene 会分阶段发送这些事件，并在每个阶段之间等待。这样可以给桌面客户端留出识别和转发修饰键状态的时间。
+
+VNC 全屏模式是已经验证过的典型场景。不过，这个问题并不只与 VNC 或远程控制有关。只要桌面客户端需要捕获或转发键盘事件，就可能受到输入时序的影响。
+
+### 各项配置分别有什么作用？
+
+- `keyboardModifierDelay`：控制一次带修饰键输入过程中，各阶段之间的等待时间。它适用于 `Control+S` 等组合键，也适用于大写字母中隐含的 `Shift`。
+- `keyboardTypeDelay`：控制连续输入文本时，相邻字符之间的等待时间。
+- `inputStrategy: 'sequential'`：逐个输入文本字符，使 Midscene 可以为大写字母和特殊字符发送对应的按键序列。
+- `keyboardLayout: 'en-US'`：启用 en-US 键盘布局中的 Shift 字符映射，例如使用 `Shift+1` 输入 `!`。
+
+拉丁大写字母不依赖 `keyboardLayout`。只有 `!`、`@`、`#` 等与键盘布局有关的 Shift 字符，才需要设置该选项。
+
+:::warning
+只有本机和目标环境都使用 en-US 键位时，才能设置 `keyboardLayout: 'en-US'`。其他键盘布局可能使用不同的标点键位，或者需要 AltGr 等修饰键。
+:::
+
+### 这个配置适用于哪些输入方式？
+
+`keyboardModifierDelay` 只对本机 libnut 键盘驱动生效。
+
+- Windows 和 Linux 的本机桌面控制使用 libnut。
+- macOS 设置 `keyboardDriver: 'libnut'` 后，也会使用这条输入路径。
+- 直接通过 RDP 协议输入时，该配置不生效。
+- macOS 使用默认的 AppleScript 键盘驱动时，该配置不生效。
+
+AppleScript 使用另一套输入方式。它是否能被桌面客户端正确识别，仍取决于客户端的快捷键拦截、键盘模式和布局转换。
+
+### 如何发送组合键？
+
+通过 `keyName` 传入组合键。使用 `+` 连接修饰键和主键，并删除 `+` 两侧的空格。
+
+```typescript
+// 向当前获得焦点的元素发送 Control+S。
+await agent.aiKeyboardPress(undefined, {
+  keyName: 'Control+S',
+});
+
+// 先定位终端窗口，再发送 Control+Shift+P。
+await agent.aiKeyboardPress('终端窗口', {
+  keyName: 'Control+Shift+P',
+});
+```
+
+请使用 `Control+S`，不要使用 `Control + S`。
+
+如果目标已经获得焦点，请将第一个参数设置为 `undefined`。这样可以避免额外点击改变当前选区或光标位置。
+
 ## 会有哪些信息发送到 AI 模型？
 
 Midscene 会发送页面截图到 AI 模型。在某些场景下，例如调用 `aiAsk` 或 `aiQuery` 时传入 `domIncluded: true`，页面的 DOM 信息也会被发送。

--- a/apps/site/docs/zh/reference/index.mdx
+++ b/apps/site/docs/zh/reference/index.mdx
@@ -2885,6 +2885,8 @@ interface LocalComputerAgentOpt extends BaseComputerAgentOpt {
   // 本机桌面选项
   displayId?: string;
   keyboardDriver?: 'applescript' | 'libnut';
+  keyboardModifierDelay?: number;
+  keyboardLayout?: 'en-US';
   headless?: boolean;
   xvfbResolution?: string;
 }
@@ -2909,6 +2911,8 @@ interface RDPComputerAgentOpt extends BaseComputerAgentOpt {
 - `displayId`（可选）：指定要控制的显示器。使用 `ComputerDevice.listDisplays()` 获取可用显示器。
 - `customActions`（可选）：添加额外的自定义动作，让 Agent 可以调用你定义的领域特定动作。
 - `keyboardDriver?: 'applescript' | 'libnut'`：macOS 的键盘事件后端。`'applescript'` 是兼容性更好的默认选项；目标应用支持时，也可以使用输入速度更快的 `'libnut'`。
+- `keyboardModifierDelay?: number`：本机 libnut 驱动的修饰键事件间隔，单位为毫秒。取值必须是有限的非负数。设置为大于 `0` 的值后，Midscene 会在修饰键状态变化和发送主键后等待。修饰键包括 `Control`、`Shift`、`Alt` 和 `Command`。因此，该选项既适用于组合键，也适用于逐键输入时大写字母中隐含的 `Shift`。设置 `keyboardLayout: 'en-US'` 后，该选项也适用于 en-US 布局的 Shift 标点。默认值为 `0`。直接使用 RDP 或 macOS AppleScript 驱动时，该选项无效。详见[通过桌面客户端转发键盘输入](../faq#keyboard-input-through-desktop-clients)。
+- `keyboardLayout?: 'en-US'`：逐键输入时，为本机 libnut 驱动启用 Shift 标点的基础键映射。拉丁大写字母不依赖该配置。其他布局保持后端原有输入行为。直接使用 RDP 或 macOS AppleScript 驱动时，该选项无效。
 - `headless`（可选，仅 Linux）：设为 `true` 时通过 [Xvfb](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml) 启动虚拟显示器，使桌面自动化能在无物理显示器的 Linux 服务器和 CI 环境中运行。也可通过环境变量 `MIDSCENE_COMPUTER_HEADLESS_LINUX=true` 设置。
 - `xvfbResolution`（可选）：Xvfb 虚拟显示器的分辨率，默认为 `'1920x1080x24'`。
 

--- a/packages/computer/README.md
+++ b/packages/computer/README.md
@@ -1,53 +1,5 @@
 # @midscene/computer
 
-Midscene.js Computer Desktop Automation - AI-powered desktop automation for:
-
-- local desktop control on Windows, macOS, and Linux
-- remote Windows desktop control over the RDP protocol
+Desktop automation library for Midscene, providing AI-powered testing and automation capabilities for Windows, macOS, and Linux, with RDP support for remote Windows desktops.
 
 See <https://midscenejs.com/platforms/desktop>.
-
-## RDP support
-
-Use `agentForRDPComputer()`:
-
-```ts
-import { agentForRDPComputer } from '@midscene/computer';
-
-const agent = await agentForRDPComputer({
-  host: '10.0.0.10',
-  username: 'Admin',
-  password: 'secret',
-  ignoreCertificate: true,
-});
-```
-
-When the machine running Midscene has multiple outbound routes, pass
-`localAddress` to bind the RDP TCP connection to a specific local source IP:
-
-```ts
-const agent = await agentForRDPComputer({
-  host: '10.0.0.10',
-  username: 'Admin',
-  password: 'secret',
-  localAddress: '10.0.0.20',
-  ignoreCertificate: true,
-});
-```
-
-RDP usage requires:
-
-- a reachable Windows machine with RDP enabled
-- [FreeRDP](https://www.freerdp.com/) installed on the machine running your script
-
-If you need to rebuild the native helper locally from source:
-
-```bash
-pnpm --filter @midscene/computer run build:native
-```
-
-Run RDP AI tests:
-
-```bash
-pnpm --filter @midscene/computer run test:ai:rdp
-```

--- a/packages/computer/src/agent-tools.ts
+++ b/packages/computer/src/agent-tools.ts
@@ -62,6 +62,20 @@ const computerInitArgShape = {
     .describe(
       'Text input strategy. "legacy" (default) preserves current Computer behavior, "sequential" sends one Unicode code point at a time, and "bulk" uses one backend input operation. "bulk" requires keyboardTypeDelay to be omitted or set to 0.',
     ),
+  keyboardModifierDelay: z
+    .number()
+    .finite()
+    .nonnegative()
+    .optional()
+    .describe(
+      'Finite non-negative delay in milliseconds after each modifier transition and the main key for local libnut keyboard events. Positive values pace shortcuts and the implicit Shift used by uppercase letters during sequential input. Layout-dependent punctuation also requires keyboardLayout. Ignored in RDP mode and by the macOS AppleScript driver.',
+    ),
+  keyboardLayout: z
+    .enum(['en-US'])
+    .optional()
+    .describe(
+      'Keyboard layout used to resolve layout-dependent shifted punctuation to base keys during sequential local libnut input. Currently only "en-US" is supported. Ignored in RDP mode and by the macOS AppleScript driver.',
+    ),
   // RDP options. Providing `host` switches connect into RDP mode and routes
   // the session through the RDP helper binary instead of the local desktop.
   // All other RDP options below are silently ignored unless `host` is set.
@@ -116,7 +130,13 @@ const computerInitArgShape = {
 export type ComputerLocalInitArgs = {
   mode: 'local';
 } & Pick<ComputerDeviceOpt, 'displayId' | 'headless'> &
-  Pick<ComputerDeviceOpt, 'inputStrategy' | 'keyboardTypeDelay'> &
+  Pick<
+    ComputerDeviceOpt,
+    | 'inputStrategy'
+    | 'keyboardTypeDelay'
+    | 'keyboardModifierDelay'
+    | 'keyboardLayout'
+  > &
   AgentBehaviorInitArgs;
 
 /** Init args for the RDP remote-desktop agent. */
@@ -136,7 +156,12 @@ export type ComputerInitArgs = ComputerLocalInitArgs | ComputerRDPInitArgs;
 type ExtractedComputerInitArgs = Partial<
   Pick<
     ComputerDeviceOpt,
-    'displayId' | 'headless' | 'inputStrategy' | 'keyboardTypeDelay'
+    | 'displayId'
+    | 'headless'
+    | 'inputStrategy'
+    | 'keyboardTypeDelay'
+    | 'keyboardModifierDelay'
+    | 'keyboardLayout'
   > &
     RDPConnectionConfig &
     AgentBehaviorInitArgs
@@ -155,7 +180,13 @@ function adaptComputerInitArgs(
   }
   if (extracted.host) {
     // Drop local-only fields; they're meaningless in RDP mode.
-    const { displayId: _d, headless: _h, ...rdpFields } = extracted;
+    const {
+      displayId: _d,
+      headless: _h,
+      keyboardModifierDelay: _s,
+      keyboardLayout: _l,
+      ...rdpFields
+    } = extracted;
     const host = normalizeRdpHost(extracted.host);
     return {
       mode: 'rdp',
@@ -169,6 +200,8 @@ function adaptComputerInitArgs(
     headless: extracted.headless,
     keyboardTypeDelay: extracted.keyboardTypeDelay,
     inputStrategy: extracted.inputStrategy,
+    keyboardModifierDelay: extracted.keyboardModifierDelay,
+    keyboardLayout: extracted.keyboardLayout,
     ...(extractAgentBehaviorInitArgs(extracted) ?? {}),
   };
 }
@@ -263,12 +296,18 @@ export class ComputerMidsceneTools extends BaseMidsceneTools<
     const headless = opts?.mode === 'local' ? opts.headless : undefined;
     const keyboardTypeDelay = opts?.keyboardTypeDelay;
     const inputStrategy = opts?.inputStrategy;
+    const keyboardModifierDelay =
+      opts?.mode === 'local' ? opts.keyboardModifierDelay : undefined;
+    const keyboardLayout =
+      opts?.mode === 'local' ? opts.keyboardLayout : undefined;
     debug('Creating Computer agent with displayId:', displayId || 'primary');
     const agentOpts = {
       ...(displayId ? { displayId } : {}),
       ...(headless !== undefined ? { headless } : {}),
       ...(keyboardTypeDelay !== undefined ? { keyboardTypeDelay } : {}),
       ...(inputStrategy !== undefined ? { inputStrategy } : {}),
+      ...(keyboardModifierDelay !== undefined ? { keyboardModifierDelay } : {}),
+      ...(keyboardLayout !== undefined ? { keyboardLayout } : {}),
       ...(this.options.keepXvfbAliveUntilProcessExit
         ? { keepXvfbAliveUntilProcessExit: true }
         : {}),

--- a/packages/computer/src/agent.ts
+++ b/packages/computer/src/agent.ts
@@ -32,6 +32,8 @@ function createLocalComputerDevice(
     keyboardTypeDelay: opts?.keyboardTypeDelay,
     inputStrategy: opts?.inputStrategy,
     keyboardDriver: opts?.keyboardDriver,
+    keyboardModifierDelay: opts?.keyboardModifierDelay,
+    keyboardLayout: opts?.keyboardLayout,
     headless: opts?.headless,
     xvfbResolution: opts?.xvfbResolution,
     keepXvfbAliveUntilProcessExit: opts?.keepXvfbAliveUntilProcessExit,

--- a/packages/computer/src/apple-script-keyboard.ts
+++ b/packages/computer/src/apple-script-keyboard.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process';
+import { getDebug } from '@midscene/shared/logger';
+
+const debugKeyboard = getDebug('computer:keyboard');
+
+const APPLE_SCRIPT_KEY_CODES: Readonly<Partial<Record<string, number>>> = {
+  return: 36,
+  enter: 36,
+  tab: 48,
+  space: 49,
+  backspace: 51,
+  delete: 51,
+  escape: 53,
+  forwarddelete: 117,
+  left: 123,
+  right: 124,
+  down: 125,
+  up: 126,
+  home: 115,
+  end: 119,
+  pageup: 116,
+  pagedown: 121,
+  f1: 122,
+  f2: 120,
+  f3: 99,
+  f4: 118,
+  f5: 96,
+  f6: 97,
+  f7: 98,
+  f8: 100,
+  f9: 101,
+  f10: 109,
+  f11: 103,
+  f12: 111,
+};
+
+const APPLE_SCRIPT_MODIFIER_KEYS: Readonly<Partial<Record<string, string>>> = {
+  command: 'command',
+  cmd: 'command',
+  control: 'control',
+  ctrl: 'control',
+  shift: 'shift',
+  alt: 'option',
+  option: 'option',
+  meta: 'command',
+};
+
+function buildKeyCommand(key: string): string {
+  const keyCode = APPLE_SCRIPT_KEY_CODES[key.toLowerCase()];
+  if (keyCode !== undefined) {
+    return `key code ${keyCode}`;
+  }
+
+  const escapedKey = key.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `keystroke "${escapedKey}"`;
+}
+
+function resolveModifierKeys(modifiers: string[]): string[] {
+  return modifiers
+    .map((modifier) => APPLE_SCRIPT_MODIFIER_KEYS[modifier.toLowerCase()])
+    .filter((modifier): modifier is string => modifier !== undefined);
+}
+
+export function buildAppleScriptKeyPress(
+  key: string,
+  modifiers: string[] = [],
+): string {
+  const modifierKeys = resolveModifierKeys(modifiers);
+  const modifierClause = modifierKeys.length
+    ? ` using {${modifierKeys
+        .map((modifier) => `${modifier} down`)
+        .join(', ')}}`
+    : '';
+  return `tell application "System Events" to ${buildKeyCommand(key)}${modifierClause}`;
+}
+
+/** Send one key press through macOS System Events without invoking a shell. */
+export function sendKeyViaAppleScript(
+  key: string,
+  modifiers: string[] = [],
+): void {
+  const script = buildAppleScriptKeyPress(key, modifiers);
+  debugKeyboard('sendKeyViaAppleScript', {
+    key,
+    modifiers,
+    script,
+  });
+  execFileSync('osascript', ['-e', script]);
+}

--- a/packages/computer/src/device.ts
+++ b/packages/computer/src/device.ts
@@ -26,11 +26,16 @@ import { sleep } from '@midscene/core/utils';
 import { createImgBase64ByFormat } from '@midscene/shared/img';
 import { getDebug } from '@midscene/shared/logger';
 import screenshot from 'screenshot-desktop';
+import { sendKeyViaAppleScript } from './apple-script-keyboard';
 import {
   ComputerInputDriver,
   type LibNut,
   type ScrollDirection,
 } from './input-driver';
+import {
+  US_SHIFTED_CHARACTER_KEYS,
+  resolveShiftedKey,
+} from './keyboard-layout';
 import { runWindowsPhysicalPixelPowershell } from './windows-dpi';
 import {
   WindowsPointerDriver,
@@ -155,34 +160,6 @@ const LIBNUT_FALLBACK_PIXELS_PER_DETENT = 100;
 const LIBNUT_FALLBACK_TICK_DELAY_MS = 30;
 const LIBNUT_FALLBACK_MAX_DETENTS = 200;
 const LIBNUT_FALLBACK_DETENT_AMOUNT = process.platform === 'win32' ? 120 : 1;
-// Work around libnut's Linux shifted-punctuation behavior for en-US layouts.
-// This is intentionally not a universal keyboard-layout map: non-US layouts
-// can place these characters on different keys or modifier levels (for example,
-// AltGr). Layout-independent support should resolve characters against the
-// active layout in the input backend instead of extending this table.
-const LINUX_SHIFTED_CHARACTER_KEYS = new Map<string, string>([
-  ['~', '`'],
-  ['!', '1'],
-  ['@', '2'],
-  ['#', '3'],
-  ['$', '4'],
-  ['%', '5'],
-  ['^', '6'],
-  ['&', '7'],
-  ['*', '8'],
-  ['(', '9'],
-  [')', '0'],
-  ['_', '-'],
-  ['+', '='],
-  ['{', '['],
-  ['}', ']'],
-  ['|', '\\'],
-  [':', ';'],
-  ['"', "'"],
-  ['<', ','],
-  ['>', '.'],
-  ['?', '/'],
-]);
 // Edge scrolls (scrollToTop / scrollToBottom / ...) must drive all the way to
 // the boundary on every backend. The phased path requests EDGE_SCROLL_TOTAL_PX
 // (50_000 px); the libnut fallback aims for the same distance, capped at
@@ -226,87 +203,6 @@ const EDGE_SCROLL_SPEC: Record<EdgeScrollType, EdgeScrollStrategy> = {
   scrollToLeft: { direction: 'left', key: 'home', libnut: [-1, 0] },
   scrollToRight: { direction: 'right', key: 'end', libnut: [1, 0] },
 };
-
-// macOS AppleScript key code mapping
-// Reference: https://eastmanreference.com/complete-list-of-applescript-key-codes
-const APPLESCRIPT_KEY_CODE_MAP: Record<string, number> = {
-  // Special keys
-  return: 36,
-  enter: 36,
-  tab: 48,
-  space: 49,
-  backspace: 51,
-  delete: 51,
-  escape: 53,
-  forwarddelete: 117,
-
-  // Arrow keys
-  left: 123,
-  right: 124,
-  down: 125,
-  up: 126,
-
-  // Navigation keys
-  home: 115,
-  end: 119,
-  pageup: 116,
-  pagedown: 121,
-
-  // Function keys
-  f1: 122,
-  f2: 120,
-  f3: 99,
-  f4: 118,
-  f5: 96,
-  f6: 97,
-  f7: 98,
-  f8: 100,
-  f9: 101,
-  f10: 109,
-  f11: 103,
-  f12: 111,
-};
-
-// Modifier key mapping for AppleScript
-const APPLESCRIPT_MODIFIER_MAP: Record<string, string> = {
-  command: 'command down',
-  cmd: 'command down',
-  control: 'control down',
-  ctrl: 'control down',
-  shift: 'shift down',
-  alt: 'option down',
-  option: 'option down',
-  meta: 'command down',
-};
-
-/**
- * Send a key press using AppleScript (macOS only)
- * More reliable than libnut for TUI applications like Bubble Tea
- */
-function sendKeyViaAppleScript(key: string, modifiers: string[] = []): void {
-  const lowerKey = key.toLowerCase();
-  const keyCode = APPLESCRIPT_KEY_CODE_MAP[lowerKey];
-
-  // Build modifier string
-  const modifierParts = modifiers
-    .map((m) => APPLESCRIPT_MODIFIER_MAP[m.toLowerCase()])
-    .filter(Boolean);
-  const modifierStr =
-    modifierParts.length > 0 ? ` using {${modifierParts.join(', ')}}` : '';
-
-  let script: string;
-
-  if (keyCode !== undefined) {
-    // Use key code for special keys
-    script = `tell application "System Events" to key code ${keyCode}${modifierStr}`;
-  } else {
-    const escapedKey = key.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    script = `tell application "System Events" to keystroke "${escapedKey}"${modifierStr}`;
-  }
-
-  debugDevice('sendKeyViaAppleScript', { key, modifiers, script });
-  execFileSync('osascript', ['-e', script]);
-}
 
 function escapePowershellSingleQuoted(value: string): string {
   return value.replace(/'/g, "''");
@@ -824,6 +720,25 @@ export interface ComputerDeviceOpt extends ComputerDeviceInputOpt {
    */
   keyboardDriver?: 'applescript' | 'libnut';
   /**
+   * Delay in milliseconds after each explicit modifier transition and the
+   * main key for local libnut keyboard events. A positive value changes
+   * modified shortcuts and shifted en-US text characters into separately
+   * observable modifier-down, main-key, and modifier-up phases. This can help
+   * foreground clients whose full-screen keyboard capture misses rapidly
+   * synthesized modifier state changes.
+   *
+   * Ignored by the macOS AppleScript driver and RDP mode.
+   * @default 0
+   */
+  keyboardModifierDelay?: number;
+  /**
+   * Keyboard layout used to resolve layout-dependent shifted characters
+   * during sequential local libnut input. Uppercase Latin letters do not
+   * require this option. Other characters keep using the backend's existing
+   * input behavior unless a supported layout is declared.
+   */
+  keyboardLayout?: 'en-US';
+  /**
    * Headless mode via Xvfb (Linux only).
    * - true: start Xvfb virtual display
    * - false/undefined: do not start Xvfb
@@ -1030,6 +945,21 @@ export class ComputerDevice implements AbstractInterface {
   };
 
   constructor(options?: ComputerDeviceOpt) {
+    if (
+      options?.keyboardModifierDelay !== undefined &&
+      (!Number.isFinite(options.keyboardModifierDelay) ||
+        options.keyboardModifierDelay < 0)
+    ) {
+      throw new Error(
+        'keyboardModifierDelay must be a finite non-negative number',
+      );
+    }
+    if (
+      options?.keyboardLayout !== undefined &&
+      options.keyboardLayout !== 'en-US'
+    ) {
+      throw new Error('keyboardLayout must be "en-US" when specified');
+    }
     this.options = options;
     this.displayId = options?.displayId;
     this.useAppleScript =
@@ -1546,7 +1476,11 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
         this.inputDriver.sendKeyViaAppleScript('v', ['command']);
       } else {
         const modifier = process.platform === 'darwin' ? 'command' : 'control';
-        this.inputDriver.keyTap('v', [modifier]);
+        await this.inputDriver.keyTapWithModifierDelay(
+          'v',
+          [modifier],
+          this.options?.keyboardModifierDelay ?? 0,
+        );
       }
       await this.inputDriver.delay(100);
     } finally {
@@ -1584,10 +1518,15 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
     await sendTextSequentially(
       text.replace(/\r\n?/g, '\n'),
       {
-        sendCharacter: (character) => {
+        sendCharacter: async (character) => {
           const linuxShiftedKey =
             process.platform === 'linux'
-              ? LINUX_SHIFTED_CHARACTER_KEYS.get(character)
+              ? US_SHIFTED_CHARACTER_KEYS.get(character)
+              : undefined;
+          const pacedShiftedKey =
+            !this.useAppleScript &&
+            (this.options?.keyboardModifierDelay ?? 0) > 0
+              ? resolveShiftedKey(character, this.options?.keyboardLayout)
               : undefined;
           if (character === '\n') {
             this.inputDriver.sendKey('return');
@@ -1597,6 +1536,12 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
             this.inputDriver.sendKey('space');
           } else if (this.useAppleScript) {
             this.inputDriver.sendKeyViaAppleScript(character);
+          } else if (pacedShiftedKey !== undefined) {
+            await this.inputDriver.keyTapWithModifierDelay(
+              pacedShiftedKey,
+              ['shift'],
+              this.options?.keyboardModifierDelay ?? 0,
+            );
           } else if (linuxShiftedKey !== undefined) {
             this.inputDriver.keyTap(linuxShiftedKey, ['shift']);
           } else {
@@ -1618,7 +1563,11 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
     }
 
     const modifier = process.platform === 'darwin' ? 'command' : 'control';
-    this.inputDriver.keyTap('a', [modifier]);
+    await this.inputDriver.keyTapWithModifierDelay(
+      'a',
+      [modifier],
+      this.options?.keyboardModifierDelay ?? 0,
+    );
     await this.inputDriver.delay(50);
     this.inputDriver.keyTap('backspace');
   }
@@ -1634,6 +1583,19 @@ $g.Dispose(); $bmp.Dispose(); $ms.Dispose()
       modifiers,
       driver: this.useAppleScript ? 'applescript' : 'libnut',
     });
+
+    if (
+      !this.useAppleScript &&
+      modifiers.length > 0 &&
+      (this.options?.keyboardModifierDelay ?? 0) > 0
+    ) {
+      await this.inputDriver.keyTapWithModifierDelay(
+        key,
+        modifiers,
+        this.options?.keyboardModifierDelay ?? 0,
+      );
+      return;
+    }
 
     this.inputDriver.sendKey(key, modifiers);
   }

--- a/packages/computer/src/input-driver.ts
+++ b/packages/computer/src/input-driver.ts
@@ -9,6 +9,7 @@ export interface LibNut {
   mouseToggle(state: 'up' | 'down', button?: MouseButton): void;
   scrollMouse(x: number, y: number): void;
   keyTap(key: string, modifiers?: string[]): void;
+  keyToggle(key: string, state: 'up' | 'down', modifiers?: string[]): void;
   typeString(text: string): void;
   getActiveWindow?(): number;
   focusWindow?(handle: number): void;
@@ -153,6 +154,68 @@ export class ComputerInputDriver {
     }
   }
 
+  keyToggle(key: string, state: 'up' | 'down', modifiers?: string[]): void {
+    const lib = this.getLibnutOrThrow('keyToggle');
+    if (modifiers !== undefined) {
+      lib.keyToggle(key, state, modifiers);
+    } else {
+      lib.keyToggle(key, state);
+    }
+  }
+
+  /**
+   * Send one modified key through libnut. A positive delay expands the compact
+   * key tap into individually observable modifier transitions. A zero delay
+   * preserves libnut's compact key-tap behavior.
+   */
+  async keyTapWithModifierDelay(
+    key: string,
+    modifiers: string[],
+    delayMs: number,
+  ): Promise<void> {
+    const uniqueModifiers = [...new Set(modifiers)];
+    if (uniqueModifiers.length === 0) {
+      this.keyTap(key);
+      return;
+    }
+    if (delayMs === 0) {
+      this.keyTap(key, uniqueModifiers);
+      return;
+    }
+
+    const pressedModifiers: string[] = [];
+    let failure: unknown;
+    try {
+      for (const modifier of uniqueModifiers) {
+        this.keyToggle(modifier, 'down');
+        pressedModifiers.push(modifier);
+        await this.delay(delayMs);
+      }
+      this.keyTap(key);
+      await this.delay(delayMs);
+    } catch (error) {
+      failure = error;
+    }
+
+    for (const modifier of pressedModifiers.reverse()) {
+      const releaseFailure = this.tryReleaseKey(modifier);
+      if (failure === undefined && releaseFailure !== undefined) {
+        failure = releaseFailure;
+      }
+      if (failure === undefined) {
+        try {
+          await this.delay(delayMs);
+        } catch (error) {
+          failure = error;
+        }
+      }
+    }
+
+    if (failure !== undefined) {
+      throw failure;
+    }
+  }
+
   typeString(text: string): void {
     this.getLibnutOrThrow('typeString').typeString(text);
   }
@@ -260,6 +323,24 @@ export class ComputerInputDriver {
       libnut.mouseToggle('up', button);
     } catch (error) {
       this.options.debug(`Failed to release mouse button ${button}: ${error}`);
+    }
+  }
+
+  private tryReleaseKey(key: string): Error | undefined {
+    try {
+      const libnut = this.options.getLibnut();
+      assert(libnut, 'libnut not initialized');
+      libnut.keyToggle(key, 'up');
+      return undefined;
+    } catch (error) {
+      const releaseError = new Error(
+        `Failed to release modifier key "${key}"`,
+        {
+          cause: error,
+        },
+      );
+      this.options.debug(`${releaseError.message}: ${error}`);
+      return releaseError;
     }
   }
 

--- a/packages/computer/src/keyboard-layout.ts
+++ b/packages/computer/src/keyboard-layout.ts
@@ -1,0 +1,49 @@
+/**
+ * Physical base keys for shifted characters on en-US keyboard layouts.
+ *
+ * This is intentionally not a universal keyboard-layout map. Other layouts
+ * can place these characters on different keys or modifier levels, such as
+ * AltGr. Layout-independent support should resolve characters against the
+ * active layout in the input backend instead of extending this table.
+ */
+export const US_SHIFTED_CHARACTER_KEYS: ReadonlyMap<string, string> = new Map([
+  ['~', '`'],
+  ['!', '1'],
+  ['@', '2'],
+  ['#', '3'],
+  ['$', '4'],
+  ['%', '5'],
+  ['^', '6'],
+  ['&', '7'],
+  ['*', '8'],
+  ['(', '9'],
+  [')', '0'],
+  ['_', '-'],
+  ['+', '='],
+  ['{', '['],
+  ['}', ']'],
+  ['|', '\\'],
+  [':', ';'],
+  ['"', "'"],
+  ['<', ','],
+  ['>', '.'],
+  ['?', '/'],
+]);
+
+/**
+ * Resolve an uppercase Latin letter, or a shifted character on an explicitly
+ * declared en-US keyboard, to its unshifted base key. Returns undefined when
+ * the character cannot be represented by the selected mapping.
+ */
+export function resolveShiftedKey(
+  character: string,
+  keyboardLayout?: 'en-US',
+): string | undefined {
+  if (/^[A-Z]$/.test(character)) {
+    return character.toLowerCase();
+  }
+
+  return keyboardLayout === 'en-US'
+    ? US_SHIFTED_CHARACTER_KEYS.get(character)
+    : undefined;
+}

--- a/packages/computer/src/types/libnut.d.ts
+++ b/packages/computer/src/types/libnut.d.ts
@@ -27,6 +27,7 @@ declare module '@computer-use/libnut/dist/import_libnut.js' {
     mouseToggle(state: ToggleState, button?: MouseButton): void;
     scrollMouse(x: number, y: number): void;
     keyTap(key: string, modifiers?: string[]): void;
+    keyToggle(key: string, state: ToggleState, modifiers?: string[]): void;
     typeString(text: string): void;
     getActiveWindow?(): number;
     getWindowRect?(handle: number): Rect;
@@ -65,6 +66,7 @@ declare module '@computer-use/libnut/dist/import_libnut' {
     mouseToggle(state: ToggleState, button?: MouseButton): void;
     scrollMouse(x: number, y: number): void;
     keyTap(key: string, modifiers?: string[]): void;
+    keyToggle(key: string, state: ToggleState, modifiers?: string[]): void;
     typeString(text: string): void;
     getActiveWindow?(): number;
     getWindowRect?(handle: number): Rect;

--- a/packages/computer/tests/unit-test/agent-tools.test.ts
+++ b/packages/computer/tests/unit-test/agent-tools.test.ts
@@ -67,6 +67,8 @@ describe('ComputerMidsceneTools', () => {
         'display-id': 'display-2',
         headless: true,
         'keyboard-type-delay': 80,
+        'keyboard-modifier-delay': 50,
+        'keyboard-layout': 'en-US',
         'input-strategy': 'sequential',
       },
     });
@@ -75,6 +77,8 @@ describe('ComputerMidsceneTools', () => {
       displayId: 'display-2',
       headless: true,
       keyboardTypeDelay: 80,
+      keyboardModifierDelay: 50,
+      keyboardLayout: 'en-US',
       inputStrategy: 'sequential',
     });
   });
@@ -171,6 +175,8 @@ describe('ComputerMidsceneTools', () => {
         'computer.headless': expect.anything(),
         'computer.inputStrategy': expect.anything(),
         'computer.keyboardTypeDelay': expect.anything(),
+        'computer.keyboardModifierDelay': expect.anything(),
+        'computer.keyboardLayout': expect.anything(),
         'computer.waitAfterAction': expect.anything(),
         'computer.replanningCycleLimit': expect.anything(),
         'computer.screenshotShrinkFactor': expect.anything(),
@@ -183,6 +189,8 @@ describe('ComputerMidsceneTools', () => {
         'computer.host': expect.anything(),
         'computer.inputStrategy': expect.anything(),
         'computer.keyboardTypeDelay': expect.anything(),
+        'computer.keyboardModifierDelay': expect.anything(),
+        'computer.keyboardLayout': expect.anything(),
         'computer.waitAfterAction': expect.anything(),
         'computer.port': expect.anything(),
         'computer.username': expect.anything(),
@@ -213,6 +221,8 @@ describe('ComputerMidsceneTools', () => {
       'ignore-certificate': true,
       'input-strategy': 'sequential',
       'keyboard-type-delay': 80,
+      'keyboard-modifier-delay': 50,
+      'keyboard-layout': 'en-US',
     });
 
     expect(agentForRDPComputer).toHaveBeenCalledWith(
@@ -227,6 +237,12 @@ describe('ComputerMidsceneTools', () => {
         inputStrategy: 'sequential',
         keyboardTypeDelay: 80,
       }),
+    );
+    expect(rs.mocked(agentForRDPComputer).mock.calls[0][0]).not.toHaveProperty(
+      'keyboardModifierDelay',
+    );
+    expect(rs.mocked(agentForRDPComputer).mock.calls[0][0]).not.toHaveProperty(
+      'keyboardLayout',
     );
     expect(agentFromComputer).not.toHaveBeenCalled();
   });

--- a/packages/computer/tests/unit-test/apple-script-keyboard.test.ts
+++ b/packages/computer/tests/unit-test/apple-script-keyboard.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@rstest/core';
+import { buildAppleScriptKeyPress } from '../../src/apple-script-keyboard';
+
+describe('AppleScript keyboard events', () => {
+  it('builds compact logical events', () => {
+    expect(buildAppleScriptKeyPress('s', ['control'])).toBe(
+      'tell application "System Events" to keystroke "s" using {control down}',
+    );
+    expect(buildAppleScriptKeyPress('K')).toBe(
+      'tell application "System Events" to keystroke "K"',
+    );
+  });
+
+  it('uses AppleScript key codes for special keys', () => {
+    expect(buildAppleScriptKeyPress('Enter', ['ctrl'])).toBe(
+      'tell application "System Events" to key code 36 using {control down}',
+    );
+  });
+});

--- a/packages/computer/tests/unit-test/device-security.test.ts
+++ b/packages/computer/tests/unit-test/device-security.test.ts
@@ -80,6 +80,7 @@ const mockState = rs.hoisted(() => {
     mouseToggle: rs.fn(),
     scrollMouse: rs.fn(),
     keyTap: rs.fn(),
+    keyToggle: rs.fn(),
     typeString: rs.fn(),
     getActiveWindow: rs.fn(() => 0),
     getWindowRect: rs.fn(),
@@ -110,6 +111,7 @@ const mockState = rs.hoisted(() => {
     libnut.mouseToggle.mockClear();
     libnut.scrollMouse.mockClear();
     libnut.keyTap.mockClear();
+    libnut.keyToggle.mockClear();
     libnut.typeString.mockClear();
     libnut.getActiveWindow.mockClear();
     libnut.getActiveWindow.mockReturnValue(0);
@@ -179,7 +181,7 @@ afterEach(() => {
 
 async function createConnectedDevice() {
   const { ComputerDevice } = await import('../../src/device');
-  const device = new ComputerDevice({});
+  const device = new ComputerDevice();
   await device.connect();
   return device;
 }
@@ -233,6 +235,15 @@ describe('ComputerDevice AppleScript security', () => {
     expect(mockState.execFileSync).toHaveBeenCalledWith('osascript', [
       '-e',
       'tell application "System Events" to keystroke "a\\"\\\\b"',
+    ]);
+  });
+
+  it('keeps logical modifier events by default', async () => {
+    await runKeyboardPress('Control+s');
+
+    expect(mockState.execFileSync).toHaveBeenCalledWith('osascript', [
+      '-e',
+      'tell application "System Events" to keystroke "s" using {control down}',
     ]);
   });
 });
@@ -325,6 +336,154 @@ describe('ComputerInputDriver native arg handling', () => {
 
     driver.keyTap('a', ['command']);
     expect(mockState.libnut.keyTap).toHaveBeenLastCalledWith('a', ['command']);
+  });
+
+  it('holds and releases explicit shortcut modifiers around the main key', async () => {
+    rs.useFakeTimers();
+    const { ComputerInputDriver } = await import('../../src/input-driver');
+    const driver = new ComputerInputDriver({
+      getLibnut: () => mockState.libnut,
+      useAppleScript: () => false,
+      sendKeyViaAppleScript: rs.fn(),
+      runPhasedScroll: rs.fn(() => true),
+      debug: rs.fn(),
+    });
+
+    const shortcut = driver.keyTapWithModifierDelay(
+      's',
+      ['control', 'shift', 'control'],
+      50,
+    );
+
+    expect(mockState.libnut.keyToggle.mock.calls).toEqual([
+      ['control', 'down'],
+    ]);
+    expect(mockState.libnut.keyTap).not.toHaveBeenCalled();
+
+    await rs.advanceTimersByTimeAsync(50);
+    expect(mockState.libnut.keyToggle.mock.calls).toEqual([
+      ['control', 'down'],
+      ['shift', 'down'],
+    ]);
+    expect(mockState.libnut.keyTap).not.toHaveBeenCalled();
+
+    await rs.advanceTimersByTimeAsync(50);
+    expect(mockState.libnut.keyTap).toHaveBeenCalledWith('s');
+    expect(mockState.libnut.keyToggle).toHaveBeenCalledTimes(2);
+
+    await rs.advanceTimersByTimeAsync(50);
+    expect(mockState.libnut.keyToggle.mock.calls).toEqual([
+      ['control', 'down'],
+      ['shift', 'down'],
+      ['shift', 'up'],
+    ]);
+
+    await rs.advanceTimersByTimeAsync(50);
+    expect(mockState.libnut.keyToggle.mock.calls).toEqual([
+      ['control', 'down'],
+      ['shift', 'down'],
+      ['shift', 'up'],
+      ['control', 'up'],
+    ]);
+
+    await rs.advanceTimersByTimeAsync(50);
+    await shortcut;
+  });
+
+  it('keeps compact modifier taps when the delay is zero', async () => {
+    const { ComputerInputDriver } = await import('../../src/input-driver');
+    const driver = new ComputerInputDriver({
+      getLibnut: () => mockState.libnut,
+      useAppleScript: () => false,
+      sendKeyViaAppleScript: rs.fn(),
+      runPhasedScroll: rs.fn(() => true),
+      debug: rs.fn(),
+    });
+
+    await driver.keyTapWithModifierDelay('s', ['control'], 0);
+
+    expect(mockState.libnut.keyTap).toHaveBeenCalledWith('s', ['control']);
+    expect(mockState.libnut.keyToggle).not.toHaveBeenCalled();
+  });
+
+  it('releases explicit shortcut modifiers when interrupted', async () => {
+    rs.useFakeTimers();
+    const { ComputerInputDriver } = await import('../../src/input-driver');
+    const driver = new ComputerInputDriver({
+      getLibnut: () => mockState.libnut,
+      useAppleScript: () => false,
+      sendKeyViaAppleScript: rs.fn(),
+      runPhasedScroll: rs.fn(() => true),
+      debug: rs.fn(),
+    });
+
+    const shortcut = driver.keyTapWithModifierDelay('s', ['control'], 50);
+    driver.destroy();
+
+    await expect(shortcut).rejects.toThrow(/destroyed/);
+    expect(mockState.libnut.keyToggle.mock.calls).toEqual([
+      ['control', 'down'],
+      ['control', 'up'],
+    ]);
+  });
+
+  it('releases remaining modifiers when interrupted between releases', async () => {
+    rs.useFakeTimers();
+    const { ComputerInputDriver } = await import('../../src/input-driver');
+    const driver = new ComputerInputDriver({
+      getLibnut: () => mockState.libnut,
+      useAppleScript: () => false,
+      sendKeyViaAppleScript: rs.fn(),
+      runPhasedScroll: rs.fn(() => true),
+      debug: rs.fn(),
+    });
+
+    const shortcut = driver.keyTapWithModifierDelay(
+      's',
+      ['control', 'shift'],
+      50,
+    );
+    await rs.advanceTimersByTimeAsync(150);
+    expect(mockState.libnut.keyToggle).toHaveBeenLastCalledWith('shift', 'up');
+
+    driver.destroy();
+
+    await expect(shortcut).rejects.toThrow(/destroyed/);
+    expect(mockState.libnut.keyToggle.mock.calls).toEqual([
+      ['control', 'down'],
+      ['shift', 'down'],
+      ['shift', 'up'],
+      ['control', 'up'],
+    ]);
+  });
+
+  it('reports modifier release failures and still releases remaining keys', async () => {
+    const { ComputerInputDriver } = await import('../../src/input-driver');
+    mockState.libnut.keyToggle.mockImplementation(
+      (key: string, state: 'up' | 'down') => {
+        if (key === 'shift' && state === 'up') {
+          throw new Error('native release failed');
+        }
+      },
+    );
+    const driver = new ComputerInputDriver({
+      getLibnut: () => mockState.libnut,
+      useAppleScript: () => false,
+      sendKeyViaAppleScript: rs.fn(),
+      runPhasedScroll: rs.fn(() => true),
+      debug: rs.fn(),
+    });
+    rs.spyOn(driver, 'delay').mockResolvedValue(undefined);
+
+    await expect(
+      driver.keyTapWithModifierDelay('s', ['control', 'shift'], 50),
+    ).rejects.toThrow('Failed to release modifier key "shift"');
+    expect(mockState.libnut.keyToggle.mock.calls).toEqual([
+      ['control', 'down'],
+      ['shift', 'down'],
+      ['shift', 'up'],
+      ['control', 'up'],
+    ]);
   });
 });
 

--- a/packages/computer/tests/unit-test/input-driver-scroll.test.ts
+++ b/packages/computer/tests/unit-test/input-driver-scroll.test.ts
@@ -11,6 +11,7 @@ function makeDriver(scrollMouse = rs.fn()) {
     mouseToggle: rs.fn(),
     scrollMouse,
     keyTap: rs.fn(),
+    keyToggle: rs.fn(),
     typeString: rs.fn(),
   };
   const driver = new ComputerInputDriver({

--- a/packages/computer/tests/unit-test/input-strategy.test.ts
+++ b/packages/computer/tests/unit-test/input-strategy.test.ts
@@ -130,6 +130,130 @@ describe('Input Strategy', () => {
     expect(typeString.mock.calls).toEqual([['A'], ['😀'], ['B']]);
   });
 
+  it('paces implicit Shift for uppercase and punctuation in sequential input', async () => {
+    const device = new ComputerDevice({
+      keyboardDriver: 'libnut',
+      inputStrategy: 'sequential',
+      keyboardModifierDelay: 50,
+      keyboardLayout: 'en-US',
+    });
+    const inputDriver = (device as any).inputDriver;
+    const typeString = rs
+      .spyOn(inputDriver, 'typeString')
+      .mockImplementation(() => {});
+    const explicitShortcut = rs
+      .spyOn(inputDriver, 'keyTapWithModifierDelay')
+      .mockResolvedValue(undefined);
+
+    await device.inputPrimitives.keyboard!.typeText('A!b😀');
+
+    expect(explicitShortcut.mock.calls).toEqual([
+      ['a', ['shift'], 50],
+      ['1', ['shift'], 50],
+    ]);
+    expect(typeString.mock.calls).toEqual([['b'], ['😀']]);
+  });
+
+  it('does not assume an en-US punctuation layout', async () => {
+    const device = new ComputerDevice({
+      keyboardDriver: 'libnut',
+      inputStrategy: 'sequential',
+      keyboardModifierDelay: 50,
+    });
+    const inputDriver = (device as any).inputDriver;
+    const typeString = rs
+      .spyOn(inputDriver, 'typeString')
+      .mockImplementation(() => {});
+    const keyTap = rs.spyOn(inputDriver, 'keyTap').mockImplementation(() => {});
+    const explicitShortcut = rs
+      .spyOn(inputDriver, 'keyTapWithModifierDelay')
+      .mockResolvedValue(undefined);
+
+    await device.inputPrimitives.keyboard!.typeText('A!');
+
+    expect(explicitShortcut).toHaveBeenCalledWith('a', ['shift'], 50);
+    expect(explicitShortcut).toHaveBeenCalledTimes(1);
+    if (process.platform === 'linux') {
+      expect(keyTap).toHaveBeenCalledWith('1', ['shift']);
+    } else {
+      expect(typeString).toHaveBeenCalledWith('!');
+    }
+  });
+
+  it('paces the select-all shortcut used before replacing input', async () => {
+    const device = new ComputerDevice({
+      keyboardDriver: 'libnut',
+      keyboardModifierDelay: 50,
+    });
+    const inputDriver = (device as any).inputDriver;
+    const explicitShortcut = rs
+      .spyOn(inputDriver, 'keyTapWithModifierDelay')
+      .mockResolvedValue(undefined);
+    const keyTap = rs.spyOn(inputDriver, 'keyTap').mockImplementation(() => {});
+    rs.spyOn(inputDriver, 'delay').mockResolvedValue(undefined);
+
+    await (device as any).selectAllAndDelete();
+
+    expect(explicitShortcut).toHaveBeenCalledWith(
+      'a',
+      [process.platform === 'darwin' ? 'command' : 'control'],
+      50,
+    );
+    expect(keyTap).toHaveBeenCalledWith('backspace');
+  });
+
+  it('uses explicit modifier phases when modifier delay is configured', async () => {
+    const device = new ComputerDevice({
+      keyboardDriver: 'libnut',
+      keyboardModifierDelay: 50,
+    });
+    const inputDriver = (device as any).inputDriver;
+    const explicitShortcut = rs
+      .spyOn(inputDriver, 'keyTapWithModifierDelay')
+      .mockResolvedValue(undefined);
+    const sendKey = rs
+      .spyOn(inputDriver, 'sendKey')
+      .mockImplementation(() => {});
+
+    await device.inputPrimitives.keyboard!.keyboardPress('Control+Shift+s');
+
+    expect(explicitShortcut).toHaveBeenCalledWith(
+      's',
+      ['control', 'shift'],
+      50,
+    );
+    expect(sendKey).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing shortcut path when modifier delay is zero', async () => {
+    const device = new ComputerDevice({
+      keyboardDriver: 'libnut',
+      keyboardModifierDelay: 0,
+    });
+    const inputDriver = (device as any).inputDriver;
+    const explicitShortcut = rs.spyOn(inputDriver, 'keyTapWithModifierDelay');
+    const sendKey = rs
+      .spyOn(inputDriver, 'sendKey')
+      .mockImplementation(() => {});
+
+    await device.inputPrimitives.keyboard!.keyboardPress('Control+s');
+
+    expect(sendKey).toHaveBeenCalledWith('s', ['control']);
+    expect(explicitShortcut).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid modifier delays and keyboard layouts', () => {
+    expect(() => new ComputerDevice({ keyboardModifierDelay: -1 })).toThrow(
+      'keyboardModifierDelay must be a finite non-negative number',
+    );
+    expect(
+      () => new ComputerDevice({ keyboardModifierDelay: Number.NaN }),
+    ).toThrow('keyboardModifierDelay must be a finite non-negative number');
+    expect(
+      () => new ComputerDevice({ keyboardLayout: 'de-DE' as any }),
+    ).toThrow('keyboardLayout must be "en-US" when specified');
+  });
+
   it('rejects bulk input with a positive device delay', async () => {
     const device = new ComputerDevice({ keyboardTypeDelay: 80 });
     const clearInput = rs.spyOn(device as any, 'selectAllAndDelete');


### PR DESCRIPTION
## Summary

- add `keyboardModifierDelay` to pace modifier-down, primary-key, and modifier-up events when using the local libnut keyboard driver
- apply the same modifier pacing to shortcuts and uppercase letters during sequential text input
- add opt-in `keyboardLayout: 'en-US'` mapping for shifted symbols such as `!`, `@`, and `#`
- preserve the existing zero-delay behavior by default
- release all pressed modifiers when an input operation fails and surface release failures to callers
- document the compatibility settings and troubleshooting guidance in English and Chinese

## Motivation

Some desktop clients capture or forward keyboard events differently from ordinary applications. When modifier and primary-key events are sent too close together, these clients may lose the modifier state.

Typical symptoms include:

- uppercase `K` becomes `k`
- `!` becomes `1`
- `Control+S` produces only `s`

The issue has been reproduced with a full-screen VNC client on Windows. The solution is not VNC-specific and can also help other desktop clients that capture or forward keyboard events.

## Usage

```typescript
const agent = await agentForComputer({
  inputStrategy: 'sequential',
  keyboardTypeDelay: 120,
  keyboardModifierDelay: 100,
  keyboardLayout: 'en-US',
});
```

`keyboardModifierDelay` is opt-in and defaults to `0`. Start with `100` when the foreground application loses modifier keys, then reduce the value if needed.

Set `keyboardLayout: 'en-US'` only when the local and target environments use the en-US key mapping.

## Scope

This behavior applies to the local libnut keyboard driver:

- Windows and Linux local desktop control
- macOS only when `keyboardDriver: 'libnut'` is selected

It does not affect:

- direct RDP input
- the default macOS AppleScript keyboard driver

## Validation

- `pnpm run lint`
- `pnpm exec nx test computer` — 133 passed, 1 skipped
- `pnpm exec nx build computer`
