### PR TITLE
refactor(test): remove create --with option

### DIFF
--- a/packages/test/src/cli/create-command.ts
+++ b/packages/test/src/cli/create-command.ts
@@ -11,11 +11,9 @@ import {
 } from './create-package-manager';
 import {
   type CreatePlatform,
-  type NodePackageSpec,
   createPlatformLabels,
   createPlatforms,
   createProjectFiles,
-  parseNodePackageSpec,
 } from './create-template';
 import type { TestCliIO } from './test-command';
 
@@ -34,13 +32,6 @@ const createParser = () =>
       choices: createPlatforms,
       requiresArg: true,
       description: 'Platform preset (prompt if omitted)',
-    })
-    .option('with', {
-      type: 'array',
-      string: true,
-      nargs: 1,
-      requiresArg: true,
-      description: 'npm Node package, optionally versioned (repeatable)',
     })
     .option('package-manager', {
       type: 'string',
@@ -65,12 +56,8 @@ const createParser = () =>
     .demandCommand(0, 1, '', 'Only one project directory is allowed.')
     .example('$0', 'Choose a directory and platform interactively')
     .example('$0 my-tests --platform web', 'Create a Web project')
-    .example(
-      '$0 . --platform android --with @acme/test-nodes@1.2.0',
-      'Include a Node package',
-    )
     .epilogue(
-      'Optionally installs dependencies with the selected package manager. The generated postinstall script creates midscene-node-reference.md after installation.\nNode packages must export a synchronous createMidsceneTestNodes(options) factory.\nExisting files are never overwritten. Setup and tests are not run during creation.',
+      'Optionally installs dependencies with the selected package manager. The generated postinstall script creates midscene-node-reference.md after installation.\nExisting files are never overwritten. Setup and tests are not run during creation.',
     )
     .help('help')
     .alias('help', 'h')
@@ -87,7 +74,6 @@ export interface CreateOptions {
   directory?: string;
   platform?: CreatePlatform;
   packageManager?: CreatePackageManager;
-  packages: NodePackageSpec[];
   yes: boolean;
   skipInstall: boolean;
   help: boolean;
@@ -105,21 +91,10 @@ export function parseCreateArgs(
   if (directory !== undefined && !directory.trim()) {
     throw new Error('Project directory must not be empty.');
   }
-  const packages = (values.with ?? []).map(parseNodePackageSpec);
-  const seen = new Set<string>();
-  for (const pkg of packages) {
-    if (seen.has(pkg.name)) {
-      throw new Error(
-        `Node package "${pkg.name}" was specified more than once.`,
-      );
-    }
-    seen.add(pkg.name);
-  }
   return {
     directory,
     platform: values.platform,
     packageManager: values['package-manager'],
-    packages,
     yes: values.yes ?? false,
     skipInstall: values['skip-install'] ?? false,
     help: values.help === true,
@@ -275,12 +250,7 @@ export async function runCreateCommand(
       .replace(/[^a-z0-9._-]/g, '-')
       .replace(/^[._-]+/, '') || 'midscene-tests';
   const commands = packageManagerCommands[packageManager];
-  const files = createProjectFiles(
-    name,
-    platform,
-    options.packages,
-    packageManager,
-  );
+  const files = createProjectFiles(name, platform, packageManager);
   checkDestinations(root, [
     ...Object.keys(files),
     'midscene-node-reference.md',

--- a/packages/test/src/cli/create-template.ts
+++ b/packages/test/src/cli/create-template.ts
@@ -21,28 +21,6 @@ export const createPlatformLabels: Record<CreatePlatform, string> = {
   computer: 'Desktop (Computer)',
 };
 
-export interface NodePackageSpec {
-  name: string;
-  version: string;
-}
-
-/** Registry packages only: keep the install spec separate from the import name. */
-export function parseNodePackageSpec(spec: string): NodePackageSpec {
-  const match =
-    /^(?:(@[a-z0-9][a-z0-9._-]*)\/)?([a-z0-9][a-z0-9._-]*)(?:@([a-zA-Z0-9^~*>=<|. +_-]+))?$/.exec(
-      spec,
-    );
-  if (!match || (match[3] !== undefined && !match[3].trim())) {
-    throw new Error(
-      `Invalid Node package "${spec}". Use an npm package name with an optional version, such as @acme/test-nodes@1.2.0.`,
-    );
-  }
-  return {
-    name: `${match[1] ? `${match[1]}/` : ''}${match[2]}`,
-    version: match[3] ?? 'latest',
-  };
-}
-
 const platformImports: Record<CreatePlatform, string> = {
   web: `import { PlaywrightAgent } from '@midscene/web/playwright/agent';
 import { createPlaywrightNodes } from '@midscene/web/playwright/test';
@@ -115,7 +93,6 @@ const platformInstructions: Record<Exclude<CreatePlatform, 'web'>, string> = {
 export function createProjectFiles(
   name: string,
   platform: CreatePlatform,
-  packages: readonly NodePackageSpec[],
   packageManager: CreatePackageManager,
 ): Record<string, string> {
   const instructions =
@@ -123,25 +100,12 @@ export function createProjectFiles(
       ? `Install Chromium before the first test: \`${packageManagerCommands[packageManager].installChromium}\`.`
       : platformInstructions[platform];
   const agentClass = agentClasses[platform];
-  const imports = packages
-    .map(
-      (pkg, index) =>
-        `import { createMidsceneTestNodes as createPackageNodes${index} } from ${JSON.stringify(pkg.name)};`,
-    )
-    .join('\n');
-  const extraNodes = packages
-    .map(
-      (_, index) =>
-        `    ...createPackageNodes${index}<ProjectContext>({ platform: '${platform}', getAgent }),`,
-    )
-    .join('\n');
   const config = `import { fileURLToPath } from 'node:url';
 import { config as loadEnv } from 'dotenv';
 import type { NodeExecutionContext } from '@midscene/test';
 import { defineProjectSetup, defineTestProject } from '@midscene/test/config';
 import { createMidsceneNodes } from '@midscene/test/midscene';
 ${platformImports[platform]}
-${imports}
 
 loadEnv({ path: fileURLToPath(new URL('.env', import.meta.url)) });
 
@@ -172,7 +136,6 @@ export default defineTestProject<ProjectContext>({
   nodes: [
     ...createMidsceneNodes<ProjectContext>({ agentClass: ${agentClass}, getAgent }),
 ${platform === 'web' ? '    ...createPlaywrightNodes<ProjectContext>({ getPage: ({ context }) => context.page }),' : ''}
-${extraNodes}
   ],
 });
 `;
@@ -184,14 +147,6 @@ ${extraNodes}
     typescript: '^5.8.3',
     ...(platform === 'web' ? { playwright: '^1.45.0' } : {}),
   };
-  for (const pkg of packages) {
-    if (Object.hasOwn(dependencies, pkg.name)) {
-      throw new Error(
-        `Node package "${pkg.name}" conflicts with a generated project dependency.`,
-      );
-    }
-    dependencies[pkg.name] = pkg.version;
-  }
   const env = platformEnv[platform];
   return {
     'package.json': `${JSON.stringify(
@@ -235,6 +190,6 @@ ${extraNodes}
           : 'cases:\n  - name: Inspect the home screen\n    steps:\n      - home: {}\n      - aiAsk: Describe the current screen\n',
     '.env.example': `# Copy this file to .env and configure your model before running tests.\n# See https://midscenejs.com/model-config.html\nMIDSCENE_MODEL_BASE_URL=\nMIDSCENE_MODEL_API_KEY=\nMIDSCENE_MODEL_NAME=\nMIDSCENE_MODEL_FAMILY=\n\n${env}`,
     '.gitignore': 'node_modules/\n.env\nmidscene_run/\n',
-    'README.md': `# ${name}\n\nA Midscene Test project for ${platform}.\n\nIf you skipped installation during creation, run \`${packageManager} ${packageManagerCommands[packageManager].install.join(' ')}\`. The \`postinstall\` script automatically generates \`midscene-node-reference.md\` after each dependency installation. If lifecycle scripts are disabled, run \`${packageManager} run nodes\` manually.\n\nCopy \`.env.example\` to \`.env\` and fill in your [model configuration](https://midscenejs.com/model-config.html).\n\n${instructions}\n\nRun tests with \`${packageManager} test\`. Read \`midscene-node-reference.md\` for the available Nodes and their inputs.\n\nAfter changing Node registrations in \`midscene.config.ts\`, run \`${packageManager} run nodes\` to refresh the reference. This loads the configuration without connecting to a device or running tests. Extension factories must only acquire runtime resources inside Node execution.\n\n${packages.length ? `Node packages: ${packages.map((pkg) => `\`${pkg.name}\``).join(', ')}. Their \`createMidsceneTestNodes\` factories are imported in the configuration.\n\n` : ''}Reports are written to \`midscene_run/report/\`.\n`,
+    'README.md': `# ${name}\n\nA Midscene Test project for ${platform}.\n\nIf you skipped installation during creation, run \`${packageManager} ${packageManagerCommands[packageManager].install.join(' ')}\`. The \`postinstall\` script automatically generates \`midscene-node-reference.md\` after each dependency installation. If lifecycle scripts are disabled, run \`${packageManager} run nodes\` manually.\n\nCopy \`.env.example\` to \`.env\` and fill in your [model configuration](https://midscenejs.com/model-config.html).\n\n${instructions}\n\nRun tests with \`${packageManager} test\`. Read \`midscene-node-reference.md\` for the available Nodes and their inputs.\n\nAfter changing Node registrations in \`midscene.config.ts\`, run \`${packageManager} run nodes\` to refresh the reference. This loads the configuration without connecting to a device or running tests. Extension factories must only acquire runtime resources inside Node execution.\n\nReports are written to \`midscene_run/report/\`.\n`,
   };
 }

--- a/packages/test/tests/create-command.test.ts
+++ b/packages/test/tests/create-command.test.ts
@@ -17,7 +17,6 @@ import {
   parseCreateArgs,
   runCreateCommand,
 } from '../src/cli/create-command';
-import { parseNodePackageSpec } from '../src/cli/create-template';
 import { renderNodeReference } from '../src/cli/node-reference';
 import { parseTestCliArgs, runTestCli } from '../src/cli/test-command';
 
@@ -87,42 +86,6 @@ describe('create arguments', () => {
       ).toBe(platform);
     },
   );
-  it('keeps directory arguments distinct from repeatable package options', () => {
-    expect(
-      parseCreateArgs(['--with', 'team-nodes', '123', '--platform', 'web']),
-    ).toMatchObject({
-      directory: '123',
-      packages: [{ name: 'team-nodes', version: 'latest' }],
-    });
-  });
-  it('parses a directory, platform, and repeatable versioned packages', () => {
-    expect(
-      parseCreateArgs([
-        'my tests',
-        '--platform=web',
-        '--with',
-        '@acme/nodes@^1.2.0',
-        '--with',
-        'other-nodes',
-        '-y',
-      ]),
-    ).toEqual({
-      directory: 'my tests',
-      platform: 'web',
-      packageManager: undefined,
-      packages: [
-        { name: '@acme/nodes', version: '^1.2.0' },
-        { name: 'other-nodes', version: 'latest' },
-      ],
-      yes: true,
-      skipInstall: false,
-      help: false,
-    });
-    expect(parseNodePackageSpec('nodes@beta')).toEqual({
-      name: 'nodes',
-      version: 'beta',
-    });
-  });
 
   it.each([
     ['a', 'b'],
@@ -130,28 +93,17 @@ describe('create arguments', () => {
     ['--platform'],
     ['--package-manager'],
     ['--package-manager', 'yarn'],
-    ['--with'],
-    ['--with', 'nodes@1', '--with', 'nodes@2'],
+    ['--with', 'nodes'],
     ['--config', 'file.ts'],
     [''],
   ])('rejects invalid arguments %j', (...args) => {
     expect(() => parseCreateArgs(args)).toThrow();
   });
 
-  it.each([
-    './nodes',
-    'https://example.com/nodes',
-    '@scope',
-    'name@',
-    'name;command',
-    'name@file:../nodes',
-    '@scope/name/subpath',
-    '__proto__',
-  ])('rejects unsupported package spec %s', (spec) => {
-    expect(() => parseNodePackageSpec(spec)).toThrow('Invalid Node package');
-  });
-
-  it('keeps --with unavailable for running tests and describing nodes', () => {
+  it('keeps --with unavailable for all commands', () => {
+    expect(() => parseCreateArgs(['--with', 'nodes'])).toThrow(
+      'Unknown argument',
+    );
     expect(() => parseTestCliArgs(['--with', 'nodes'])).toThrow(
       'Unknown option',
     );
@@ -379,14 +331,10 @@ describe('create project', () => {
     },
   );
 
-  it('installs before describing, writes the reference, and persists package imports', async () => {
+  it('installs before describing and writes the generated project', async () => {
     const cwd = temp();
     const runtime = services(cwd);
-    await runCreateCommand(
-      ['my tests', '--platform', 'web', '--with', '@acme/nodes@1.2.0'],
-      io(),
-      runtime,
-    );
+    await runCreateCommand(['my tests', '--platform', 'web'], io(), runtime);
     const root = join(cwd, 'my tests');
     expect(runtime.promptDirectory).not.toHaveBeenCalled();
     expect(runtime.runPackageManager).toHaveBeenNthCalledWith(
@@ -408,7 +356,6 @@ describe('create project', () => {
       readFileSync(join(root, 'package.json'), 'utf8'),
     );
     expect(manifest.name).toBe('my-tests');
-    expect(manifest.devDependencies['@acme/nodes']).toBe('1.2.0');
     expect(manifest.devDependencies['@midscene/test']).toBe(
       manifest.devDependencies['@midscene/web'],
     );
@@ -418,8 +365,6 @@ describe('create project', () => {
     expect(config).toContain("from '@midscene/web/playwright/agent'");
     expect(config).toContain("from '@midscene/web/playwright/test'");
     expect(config).not.toContain('@midscene/test/playwright');
-    expect(config).toContain('from "@acme/nodes"');
-    expect(config).not.toContain('@acme/nodes@1.2.0');
     expect(existsSync(join(root, '.env'))).toBe(false);
     expect(existsSync(join(root, 'README.md'))).toBe(true);
     expect(existsSync(join(root, 'README.zh.md'))).toBe(false);
@@ -507,18 +452,6 @@ describe('create project', () => {
       runCreateCommand(['.', '--platform', 'web'], io(), services(cwd)),
     ).rejects.toThrow('Cannot create project');
     expect(readdirSync(cwd)).toEqual(['package.json']);
-  });
-
-  it('rejects extension packages that replace generated dependencies', async () => {
-    const cwd = temp();
-    await expect(
-      runCreateCommand(
-        ['.', '--platform', 'web', '--with', '@midscene/test'],
-        io(),
-        services(cwd),
-      ),
-    ).rejects.toThrow('conflicts with a generated project dependency');
-    expect(readdirSync(cwd)).toEqual([]);
   });
 
   it('preserves files and explains recovery after installation fails', async () => {

--- a/packages/test/tests/e2e/create-cli.test.ts
+++ b/packages/test/tests/e2e/create-cli.test.ts
@@ -331,7 +331,7 @@ describe('generated project integration', () => {
     async (format) => {
       const cwd = temp();
       for (const [filename, content] of Object.entries(
-        createProjectFiles('agent-entry', 'web', [], 'pnpm'),
+        createProjectFiles('agent-entry', 'web', 'pnpm'),
       )) {
         const path = join(cwd, filename);
         mkdirSync(resolve(path, '..'), { recursive: true });
@@ -403,125 +403,6 @@ describe('generated project integration', () => {
         `,
         ],
         { cwd, env: { ...process.env, NODE_PATH: '' } },
-      );
-    },
-  );
-
-  it.each([
-    ['web', 'esm'],
-    ['web', 'cjs'],
-    ['harmony', 'esm'],
-    ['computer', 'esm'],
-  ])(
-    'includes an external package in the %s Node reference (%s)',
-    async (platform, format) => {
-      const cwd = temp();
-      const runtime = services(cwd);
-      runtime.runPackageManager = async (_packageManager, args, root) => {
-        if (args[0] === 'install') {
-          linkDependencies(root);
-          const pkg = join(root, 'node_modules', 'team-nodes');
-          mkdirSync(pkg);
-          writeFileSync(
-            join(pkg, 'package.json'),
-            JSON.stringify({
-              name: 'team-nodes',
-              main: format === 'esm' ? 'index.mjs' : 'index.cjs',
-              types: 'index.d.ts',
-            }),
-          );
-          writeFileSync(
-            join(pkg, format === 'esm' ? 'index.mjs' : 'index.cjs'),
-            `${format === 'esm' ? 'export function createMidsceneTestNodes' : 'exports.createMidsceneTestNodes = function'}(options) {
-          if (options.platform !== ${JSON.stringify(platform)}) throw new Error('Unsupported platform');
-          return [{ name: 'team.inspect', description: 'Inspect the screen.', async execute(ctx) { return (await options.getAgent(ctx)).aiAsk('Describe the screen'); } }];
-        }`,
-          );
-          writeFileSync(
-            join(pkg, 'index.d.ts'),
-            `import type { NodeDefinition } from '@midscene/test';
-import type { NodePackageOptions } from '@midscene/test/config';
-export declare function createMidsceneTestNodes<TContext>(options: NodePackageOptions<TContext>): NodeDefinition<unknown, unknown, TContext>[];
-`,
-          );
-          return '';
-        }
-        return (
-          await execFileAsync(
-            process.execPath,
-            [join(packageRoot, 'bin/midscene-test'), 'nodes'],
-            { cwd: root },
-          )
-        ).stdout;
-      };
-      await runCreateCommand(
-        ['.', '--platform', platform, '--with', 'team-nodes@1.0.0'],
-        io(),
-        runtime,
-      );
-      expect(
-        readFileSync(join(cwd, 'midscene-node-reference.md'), 'utf8'),
-      ).toContain('## `team.inspect`');
-      await execFileAsync(process.execPath, [
-        join(packageRoot, 'node_modules/typescript/bin/tsc'),
-        '-p',
-        cwd,
-      ]);
-    },
-    30000,
-  );
-
-  it.each([
-    ['missing factory', 'export const nodes = [];'],
-    [
-      'async factory',
-      'export async function createMidsceneTestNodes() { return []; }',
-    ],
-    [
-      'duplicate Node',
-      "export function createMidsceneTestNodes() { return [{ name: 'aiAsk', execute() {} }]; }",
-    ],
-    [
-      'invalid Node',
-      "export function createMidsceneTestNodes() { return [{ name: 'team.invalid' }]; }",
-    ],
-  ])(
-    'reports an external package with %s and preserves the project',
-    async (_, source) => {
-      const cwd = temp();
-      const runtime = services(cwd);
-      runtime.runPackageManager = async (_packageManager, args, root) => {
-        if (args[0] === 'install') {
-          linkDependencies(root);
-          const pkg = join(root, 'node_modules', 'broken-nodes');
-          mkdirSync(pkg);
-          writeFileSync(
-            join(pkg, 'package.json'),
-            JSON.stringify({ name: 'broken-nodes', main: 'index.mjs' }),
-          );
-          writeFileSync(join(pkg, 'index.mjs'), source);
-          return '';
-        }
-        return (
-          await execFileAsync(
-            process.execPath,
-            [join(packageRoot, 'bin/midscene-test'), 'nodes'],
-            { cwd: root },
-          )
-        ).stdout;
-      };
-      const output = io();
-      await expect(
-        runCreateCommand(
-          ['.', '--platform', 'web', '--with', 'broken-nodes'],
-          output,
-          runtime,
-        ),
-      ).rejects.toThrow('Node reference generation failed');
-      expect(existsSync(join(cwd, 'midscene.config.ts'))).toBe(true);
-      expect(existsSync(join(cwd, 'midscene-node-reference.md'))).toBe(false);
-      expect(output.log.mock.calls.flat().join('\n')).not.toContain(
-        'Project ready',
       );
     },
   );


### PR DESCRIPTION
### Motivation
- Simplify the `midscene-test create` workflow by removing the `--with` option and the associated external Node package injection, avoiding complexity and fragile template generation paths.

### Description
- Remove `--with` CLI option handling and `NodePackageSpec` parsing from `packages/test/src/cli/create-command.ts` and `packages/test/src/cli/create-template.ts`.
- Simplify `createProjectFiles` signature to `createProjectFiles(name, platform, packageManager)` and strip code that injected external package imports, Node registrations, dependency entries, and README text referencing added packages.
- Update `runCreateCommand` to stop collecting `options.packages` and to call the simplified `createProjectFiles` API, and adjust help/epilogue/examples to no longer advertise `--with` usage.
- Update unit and e2e tests in `packages/test/tests/*` to assert that `--with` is rejected for all commands and to remove/replace tests that exercised external package injection and Node description flows.

### Testing
- Ran targeted lint checks with `pnpm exec biome check` on the modified files which reported no new issues for those files.
- Ran the focused unit suite with `pnpm --filter @midscene/test test tests/create-command.test.ts` and it passed (`67` tests).
- Ran the focused e2e create CLI suite with `pnpm --filter @midscene/test exec vitest --run --config vitest.e2e.config.ts tests/e2e/create-cli.test.ts` and it passed (`16` tests).
- Built the package with `pnpm exec nx build @midscene/test`, which succeeded; running the full `pnpm exec nx test @midscene/test` shows unrelated failures caused by missing report templates and other workspace build artifacts rather than the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa14a5576e08324a0f54367f4aaec40)