### PR TITLE
fix(core): preserve global config for custom clients

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -338,9 +338,11 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
   }
 
   private resolveModelRuntime(intent: TIntent): ModelRuntime {
-    const runtime = getModelRuntime(
-      this.modelConfigManager.getModelConfig(intent),
-    );
+    const modelConfig: IModelConfig = {
+      ...this.modelConfigManager.getModelConfig(intent),
+      createOpenAIClient: this.opts.createOpenAIClient,
+    };
+    const runtime = getModelRuntime(modelConfig);
     return {
       ...runtime,
       onUsage: (usage) => {
@@ -432,11 +434,10 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
         `opts.modelConfig must be a plain object map of env keys to values, but got ${typeof opts?.modelConfig}`,
       );
     }
-    // Create ModelConfigManager if modelConfig or createOpenAIClient is provided
-    // Otherwise, use the global config manager
-    const hasCustomConfig = opts?.modelConfig || opts?.createOpenAIClient;
-    this.modelConfigManager = hasCustomConfig
-      ? new ModelConfigManager(opts?.modelConfig, opts?.createOpenAIClient)
+    // Explicit modelConfig is isolated from global configuration.
+    // A custom client factory alone still uses the global model values.
+    this.modelConfigManager = opts?.modelConfig
+      ? new ModelConfigManager(opts.modelConfig, opts.createOpenAIClient)
       : globalModelConfigManager;
 
     this.onTaskStartTip = this.opts.onTaskStartTip;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -140,19 +140,6 @@ class AgentScopedModelConfigManager extends ModelConfigManager {
       createOpenAIClient: this.createOpenAIClient,
     };
   }
-
-  override getUploadTestServerUrl(): string | undefined {
-    return this.baseManager.getUploadTestServerUrl();
-  }
-
-  override throwErrorIfNonVLModel() {
-    const modelConfig = this.getModelConfig('default');
-    if (!modelConfig.modelFamily) {
-      throw new Error(
-        'MIDSCENE_MODEL_FAMILY is not set to a multimodal model with UI localization, so element localization cannot be achieved. Check your model configuration. See https://midscenejs.com/model-strategy.html',
-      );
-    }
-  }
 }
 
 export type AiActOptions = {
@@ -368,10 +355,9 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
   }
 
   private resolveModelRuntime(intent: TIntent): ModelRuntime {
-    const modelConfig: IModelConfig = {
-      ...this.modelConfigManager.getModelConfig(intent),
-    };
-    const runtime = getModelRuntime(modelConfig);
+    const runtime = getModelRuntime(
+      this.modelConfigManager.getModelConfig(intent),
+    );
     return {
       ...runtime,
       onUsage: (usage) => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -70,6 +70,7 @@ import {
   observationArtifactAdapterSymbol,
 } from '@midscene/shared/agent-tools/observation-artifact';
 import {
+  type CreateOpenAIClientFn,
   type IModelConfig,
   MIDSCENE_REPLANNING_CYCLE_LIMIT,
   ModelConfigManager,
@@ -124,6 +125,35 @@ import {
 
 const debug = getDebug('agent');
 const warn = getDebug('agent', { console: true });
+
+class AgentScopedModelConfigManager extends ModelConfigManager {
+  constructor(
+    private readonly baseManager: ModelConfigManager,
+    private readonly createOpenAIClient?: CreateOpenAIClientFn,
+  ) {
+    super();
+  }
+
+  override getModelConfig(intent: TIntent): IModelConfig {
+    return {
+      ...this.baseManager.getModelConfig(intent),
+      createOpenAIClient: this.createOpenAIClient,
+    };
+  }
+
+  override getUploadTestServerUrl(): string | undefined {
+    return this.baseManager.getUploadTestServerUrl();
+  }
+
+  override throwErrorIfNonVLModel() {
+    const modelConfig = this.getModelConfig('default');
+    if (!modelConfig.modelFamily) {
+      throw new Error(
+        'MIDSCENE_MODEL_FAMILY is not set to a multimodal model with UI localization, so element localization cannot be achieved. Check your model configuration. See https://midscenejs.com/model-strategy.html',
+      );
+    }
+  }
+}
 
 export type AiActOptions = {
   cacheable?: boolean;
@@ -340,7 +370,6 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
   private resolveModelRuntime(intent: TIntent): ModelRuntime {
     const modelConfig: IModelConfig = {
       ...this.modelConfigManager.getModelConfig(intent),
-      createOpenAIClient: this.opts.createOpenAIClient,
     };
     const runtime = getModelRuntime(modelConfig);
     return {
@@ -438,7 +467,12 @@ export class Agent<InterfaceType extends AbstractInterface = AbstractInterface>
     // A custom client factory alone still uses the global model values.
     this.modelConfigManager = opts?.modelConfig
       ? new ModelConfigManager(opts.modelConfig, opts.createOpenAIClient)
-      : globalModelConfigManager;
+      : opts?.createOpenAIClient
+        ? new AgentScopedModelConfigManager(
+            globalModelConfigManager,
+            opts.createOpenAIClient,
+          )
+        : globalModelConfigManager;
 
     this.onTaskStartTip = this.opts.onTaskStartTip;
 

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -11,6 +11,7 @@ import {
   MIDSCENE_PLANNING_MODEL_API_KEY,
   MIDSCENE_PLANNING_MODEL_BASE_URL,
   MIDSCENE_PLANNING_MODEL_NAME,
+  overrideAIConfig,
 } from '@midscene/shared/env';
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 
@@ -40,9 +41,11 @@ const createMockInterface = () =>
 describe('Agent with custom OpenAI client', () => {
   beforeEach(() => {
     rs.mock('openai');
+    overrideAIConfig(defaultModelConfig);
   });
 
   afterEach(() => {
+    overrideAIConfig({});
     rs.clearAllMocks();
   });
 
@@ -245,6 +248,29 @@ describe('Agent with custom OpenAI client', () => {
   });
 
   describe('constructor with createOpenAIClient', () => {
+    it('should combine global model config with an agent-scoped createOpenAIClient', () => {
+      const mockCreateClient: CreateOpenAIClientFn = rs.fn(async () => ({
+        chat: { completions: { create: rs.fn() } },
+      }));
+      const agent = new Agent(createMockInterface(), {
+        createOpenAIClient: mockCreateClient,
+      });
+
+      const runtime = (agent as any).resolveModelRuntime('default');
+
+      expect(runtime.config.modelName).toBe(
+        defaultModelConfig[MIDSCENE_MODEL_NAME],
+      );
+      expect(runtime.config.openaiApiKey).toBe(
+        defaultModelConfig[MIDSCENE_MODEL_API_KEY],
+      );
+      expect(runtime.config.openaiBaseURL).toBe(
+        defaultModelConfig[MIDSCENE_MODEL_BASE_URL],
+      );
+      expect(runtime.config.createOpenAIClient).toBe(mockCreateClient);
+      expect(mockCreateClient).not.toHaveBeenCalled();
+    });
+
     it('should accept createOpenAIClient in AgentOpt with modelConfig', () => {
       const mockCreateClient = rs.fn(async () => ({
         chat: { completions: { create: rs.fn() } },

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -271,6 +271,40 @@ describe('Agent with custom OpenAI client', () => {
       expect(mockCreateClient).not.toHaveBeenCalled();
     });
 
+    it('should isolate createOpenAIClient between agents sharing global config', () => {
+      const firstCreateClient: CreateOpenAIClientFn = rs.fn(async () => ({
+        chat: { completions: { create: rs.fn() } },
+      }));
+      const secondCreateClient: CreateOpenAIClientFn = rs.fn(async () => ({
+        chat: { completions: { create: rs.fn() } },
+      }));
+      const firstAgent = new Agent(createMockInterface(), {
+        createOpenAIClient: firstCreateClient,
+      });
+      const secondAgent = new Agent(createMockInterface(), {
+        createOpenAIClient: secondCreateClient,
+      });
+
+      const firstRuntime = (firstAgent as any).resolveModelRuntime('default');
+      const secondRuntime = (secondAgent as any).resolveModelRuntime('default');
+      const firstRuntimeAgain = (firstAgent as any).resolveModelRuntime(
+        'default',
+      );
+
+      expect(firstRuntime.config.modelName).toBe(
+        defaultModelConfig[MIDSCENE_MODEL_NAME],
+      );
+      expect(secondRuntime.config.modelName).toBe(
+        defaultModelConfig[MIDSCENE_MODEL_NAME],
+      );
+      expect(firstRuntime.config).not.toBe(secondRuntime.config);
+      expect(firstRuntime.config.createOpenAIClient).toBe(firstCreateClient);
+      expect(secondRuntime.config.createOpenAIClient).toBe(secondCreateClient);
+      expect(firstRuntimeAgain.config.createOpenAIClient).toBe(
+        firstCreateClient,
+      );
+    });
+
     it('should accept createOpenAIClient in AgentOpt with modelConfig', () => {
       const mockCreateClient = rs.fn(async () => ({
         chat: { completions: { create: rs.fn() } },

--- a/packages/core/tests/unit-test/agent-custom-model.test.ts
+++ b/packages/core/tests/unit-test/agent-custom-model.test.ts
@@ -11,7 +11,7 @@ import {
   MIDSCENE_PLANNING_MODEL_API_KEY,
   MIDSCENE_PLANNING_MODEL_BASE_URL,
   MIDSCENE_PLANNING_MODEL_NAME,
-  overrideAIConfig,
+  globalModelConfigManager,
 } from '@midscene/shared/env';
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 
@@ -38,14 +38,22 @@ const createMockInterface = () =>
     actionSpace: () => [],
   }) as any;
 
+const stubModelEnv = (config: Record<string, string>) => {
+  for (const [key, value] of Object.entries(config)) {
+    rs.stubEnv(key, value);
+  }
+  globalModelConfigManager.clearModelConfigMap();
+};
+
 describe('Agent with custom OpenAI client', () => {
   beforeEach(() => {
     rs.mock('openai');
-    overrideAIConfig(defaultModelConfig);
+    stubModelEnv(defaultModelConfig);
   });
 
   afterEach(() => {
-    overrideAIConfig({});
+    rs.unstubAllEnvs();
+    globalModelConfigManager.clearModelConfigMap();
     rs.clearAllMocks();
   });
 
@@ -248,6 +256,27 @@ describe('Agent with custom OpenAI client', () => {
   });
 
   describe('constructor with createOpenAIClient', () => {
+    it('should expose createOpenAIClient on public modelConfigManager for factory-only agents', () => {
+      const mockCreateClient: CreateOpenAIClientFn = rs.fn(async () => ({
+        chat: { completions: { create: rs.fn() } },
+      }));
+      const agent = new Agent(createMockInterface(), {
+        createOpenAIClient: mockCreateClient,
+      });
+
+      const defaultConfig = agent.modelConfigManager.getModelConfig('default');
+      const insightConfig = agent.modelConfigManager.getModelConfig('insight');
+
+      expect(defaultConfig.modelName).toBe(
+        defaultModelConfig[MIDSCENE_MODEL_NAME],
+      );
+      expect(defaultConfig.createOpenAIClient).toBe(mockCreateClient);
+      expect(insightConfig.modelName).toBe(
+        defaultModelConfig[MIDSCENE_MODEL_NAME],
+      );
+      expect(insightConfig.createOpenAIClient).toBe(mockCreateClient);
+    });
+
     it('should combine global model config with an agent-scoped createOpenAIClient', () => {
       const mockCreateClient: CreateOpenAIClientFn = rs.fn(async () => ({
         chat: { completions: { create: rs.fn() } },


### PR DESCRIPTION
This draft PR replays the five reviewed commits from #3094 onto current main to run CI from a branch in this repository. The fix preserves global model configuration for agents that provide only `createOpenAIClient`, while keeping the custom client factory scoped to each agent. Related issue: #3079.

Original implementation: @linhongyu510 in #3094, reviewed head `283c3fd0c46201e4d8c6afccf4613af52dc99269`. Commits were replayed using the GitHub API; each commit retains its source SHA and a co-author trailer. No workflow or dependency changes are included.

Validation on an isolated snapshot based on main `1c7a8d6cd5f0788699c83f532422130b0ad52190`:
- `pnpm run lint` — passed, no fixes applied.
- `NX_DAEMON=false pnpm exec nx test @midscene/core -- tests/unit-test/agent-custom-model.test.ts` — passed, 21 tests.
- `NX_DAEMON=false pnpm exec nx build @midscene/core` — passed. The isolated snapshot has no built report app, so the core build retained its placeholder report template.

This PR is for same-repository CI validation; the original PR remains open.