### PR TITLE
docs(site): update DeepSeek Flash model configuration

### DIFF
--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -132,11 +132,11 @@ Midscene supports DeepSeek starting from v1.12.0.
 
 | Model version | Commonly used model names | `MIDSCENE_MODEL_FAMILY` | Notes |
 | --- | --- | --- | --- |
-| DeepSeek V4 series | `deepseek-v4-flash-vision-exp` | `deepseek` | Currently, only `deepseek-v4-flash-vision-exp` supports the multimodal visual input required by Midscene. Other DeepSeek V4 models, including `deepseek-v4-pro` and `deepseek-v4-flash`, are not suitable for use with Midscene. |
+| DeepSeek V4 series | `deepseek-flash` | `deepseek` | `deepseek-flash` natively supports the multimodal visual input required by Midscene. `deepseek-v4-pro` does not currently support multimodal visual input and is not suitable for use with Midscene. See [DeepSeek model details](https://api-docs.deepseek.com/quick_start/pricing/). |
 
 </div>
 
-Environment variable configuration example, using `deepseek-v4-flash-vision-exp`:
+Environment variable configuration example, using `deepseek-flash`:
 
 <ModelConfigTabs>
   <ModelConfigTab type="default">
@@ -144,7 +144,7 @@ Environment variable configuration example, using `deepseek-v4-flash-vision-exp`
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API endpoint
 MIDSCENE_MODEL_API_KEY="......"
-MIDSCENE_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_MODEL_NAME="deepseek-flash"
 MIDSCENE_MODEL_FAMILY="deepseek"
 ```
 
@@ -154,7 +154,7 @@ MIDSCENE_MODEL_FAMILY="deepseek"
 ```bash
 MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API endpoint
 MIDSCENE_PLANNING_MODEL_API_KEY="......"
-MIDSCENE_PLANNING_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_PLANNING_MODEL_NAME="deepseek-flash"
 MIDSCENE_PLANNING_MODEL_FAMILY="deepseek"
 ```
 
@@ -164,7 +164,7 @@ MIDSCENE_PLANNING_MODEL_FAMILY="deepseek"
 ```bash
 MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API endpoint
 MIDSCENE_INSIGHT_MODEL_API_KEY="......"
-MIDSCENE_INSIGHT_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_INSIGHT_MODEL_NAME="deepseek-flash"
 MIDSCENE_INSIGHT_MODEL_FAMILY="deepseek"
 ```
 

--- a/apps/site/docs/en/model-common-config.mdx
+++ b/apps/site/docs/en/model-common-config.mdx
@@ -132,7 +132,7 @@ Midscene supports DeepSeek starting from v1.12.0.
 
 | Model version | Commonly used model names | `MIDSCENE_MODEL_FAMILY` | Notes |
 | --- | --- | --- | --- |
-| DeepSeek V4 series | `deepseek-flash` | `deepseek` | `deepseek-flash` natively supports the multimodal visual input required by Midscene. `deepseek-v4-pro` does not currently support multimodal visual input and is not suitable for use with Midscene. See [DeepSeek model details](https://api-docs.deepseek.com/quick_start/pricing/). |
+| DeepSeek V4 series | `deepseek-flash` (V4.1 Flash), `deepseek-v4-flash-vision-exp` (V4 Flash Vision) | `deepseek` | DeepSeek-V4-Pro does not support visual input and cannot be used with Midscene. |
 
 </div>
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -132,7 +132,7 @@ Midscene 从 v1.12.0 开始支持 DeepSeek。
 
 | 模型版本 | 常用模型名称 | `MIDSCENE_MODEL_FAMILY` | 备注 |
 | --- | --- | --- | --- |
-| DeepSeek V4 系列 | `deepseek-flash` | `deepseek` | `deepseek-flash` 已原生支持 Midscene 所需的多模态视觉输入。`deepseek-v4-pro` 目前尚不支持多模态视觉输入，不适用于 Midscene。详见 [DeepSeek 模型说明](https://api-docs.deepseek.com/zh-cn/quick_start/pricing/)。 |
+| DeepSeek V4 系列 | `deepseek-flash`（V4.1 Flash）、`deepseek-v4-flash-vision-exp`（V4 Flash Vision） | `deepseek` | DeepSeek-V4-Pro 不支持视觉输入，不能用于 Midscene。 |
 
 </div>
 

--- a/apps/site/docs/zh/model-common-config.mdx
+++ b/apps/site/docs/zh/model-common-config.mdx
@@ -122,7 +122,7 @@ MIDSCENE_INSIGHT_MODEL_FAMILY="qwen3" # 如果你使用了其他版本的 Qwen�
   </ModelConfigTab>
 </ModelConfigTabs>
 
-### DeepSeek 系列 {#deepseek}
+### 深度求索 deepseek 系列 {#deepseek}
 
 Midscene 从 v1.12.0 开始支持 DeepSeek。
 
@@ -132,11 +132,11 @@ Midscene 从 v1.12.0 开始支持 DeepSeek。
 
 | 模型版本 | 常用模型名称 | `MIDSCENE_MODEL_FAMILY` | 备注 |
 | --- | --- | --- | --- |
-| DeepSeek V4 系列 | `deepseek-v4-flash-vision-exp` | `deepseek` | 目前只有 `deepseek-v4-flash-vision-exp` 支持 Midscene 所需的多模态视觉输入。包括 `deepseek-v4-pro` 和普通 `deepseek-v4-flash` 在内的其他 DeepSeek V4 模型均不适用于 Midscene。 |
+| DeepSeek V4 系列 | `deepseek-flash` | `deepseek` | `deepseek-flash` 已原生支持 Midscene 所需的多模态视觉输入。`deepseek-v4-pro` 目前尚不支持多模态视觉输入，不适用于 Midscene。详见 [DeepSeek 模型说明](https://api-docs.deepseek.com/zh-cn/quick_start/pricing/)。 |
 
 </div>
 
-环境变量配置示例，以 `deepseek-v4-flash-vision-exp` 为例：
+环境变量配置示例，以 `deepseek-flash` 为例：
 
 <ModelConfigTabs>
   <ModelConfigTab type="default">
@@ -144,7 +144,7 @@ Midscene 从 v1.12.0 开始支持 DeepSeek。
 ```bash
 MIDSCENE_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API 地址
 MIDSCENE_MODEL_API_KEY="......"
-MIDSCENE_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_MODEL_NAME="deepseek-flash"
 MIDSCENE_MODEL_FAMILY="deepseek"
 ```
 
@@ -154,7 +154,7 @@ MIDSCENE_MODEL_FAMILY="deepseek"
 ```bash
 MIDSCENE_PLANNING_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API 地址
 MIDSCENE_PLANNING_MODEL_API_KEY="......"
-MIDSCENE_PLANNING_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_PLANNING_MODEL_NAME="deepseek-flash"
 MIDSCENE_PLANNING_MODEL_FAMILY="deepseek"
 ```
 
@@ -164,7 +164,7 @@ MIDSCENE_PLANNING_MODEL_FAMILY="deepseek"
 ```bash
 MIDSCENE_INSIGHT_MODEL_BASE_URL="https://api.deepseek.com" # DeepSeek API 地址
 MIDSCENE_INSIGHT_MODEL_API_KEY="......"
-MIDSCENE_INSIGHT_MODEL_NAME="deepseek-v4-flash-vision-exp"
+MIDSCENE_INSIGHT_MODEL_NAME="deepseek-flash"
 MIDSCENE_INSIGHT_MODEL_FAMILY="deepseek"
 ```
 


### PR DESCRIPTION
Update the English and Chinese DeepSeek configuration docs to use `deepseek-flash` in the model table and all three configuration examples. Clarify that Flash natively supports the visual input required by Midscene while V4 Pro currently does not, and link to the official model details. Add the Chinese company name to the Chinese section heading.

Validation: `pnpm run lint` and `git diff --check` passed.