### PR TITLE
fix(core): clarify and validate scroll and swipe actions

### DIFF
--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -750,22 +750,25 @@ export const ActionSwipeParamSchema = z.object({
   start: getMidsceneLocationSchema()
     .optional()
     .describe(
-      'Starting point of the swipe gesture, if not specified, the center of the page will be used',
+      'Optional starting point of the finger movement. Available in both relative and endpoint forms. If omitted, the center of the page is used.',
     ),
   direction: z
     .enum(['up', 'down', 'left', 'right'])
     .optional()
     .describe(
-      'The direction to swipe (required when using distance). The direction means the direction of the finger swipe.',
+      'Finger movement direction. Required together with a positive distance for a relative swipe. Omit when using end.',
     ),
   distance: z
     .number()
+    .positive()
     .optional()
-    .describe('The distance in pixels to swipe (mutually exclusive with end)'),
+    .describe(
+      'Positive length of the finger movement in pixels. Required together with direction for a relative swipe. Omit when using end.',
+    ),
   end: getMidsceneLocationSchema()
     .optional()
     .describe(
-      'Ending point of the swipe gesture (mutually exclusive with distance)',
+      'Endpoint of the finger movement. Use for an endpoint swipe, optionally with start. Do not provide direction or distance when using end.',
     ),
   duration: z
     .number()
@@ -804,36 +807,46 @@ export function normalizeMobileSwipeParam(
     ? { x: start.center[0], y: start.center[1] }
     : { x: width / 2, y: height / 2 };
 
-  let endPoint: { x: number; y: number };
+  const endPoint = (() => {
+    if (end) {
+      if (param.direction !== undefined || param.distance !== undefined) {
+        throw new Error(
+          'Invalid Swipe parameters: "end" cannot be combined with "direction" or "distance". Use "end", optionally with "start", for an endpoint swipe.',
+        );
+      }
 
-  if (end) {
-    endPoint = { x: end.center[0], y: end.center[1] };
-  } else if (param.distance) {
-    const direction = param.direction;
-    if (!direction) {
-      throw new Error('direction is required for swipe gesture');
+      return { x: end.center[0], y: end.center[1] };
     }
-    endPoint = {
+
+    if (param.direction === undefined || param.distance === undefined) {
+      throw new Error(
+        'Invalid Swipe parameters: a relative swipe requires both "direction" and a positive "distance".',
+      );
+    }
+
+    if (param.distance <= 0) {
+      throw new Error(
+        'Invalid Swipe parameters: "distance" must be a positive number.',
+      );
+    }
+
+    return {
       x:
         startPoint.x +
-        (direction === 'right'
+        (param.direction === 'right'
           ? param.distance
-          : direction === 'left'
+          : param.direction === 'left'
             ? -param.distance
             : 0),
       y:
         startPoint.y +
-        (direction === 'down'
+        (param.direction === 'down'
           ? param.distance
-          : direction === 'up'
+          : param.direction === 'up'
             ? -param.distance
             : 0),
     };
-  } else {
-    throw new Error(
-      'Either end or distance must be specified for swipe gesture',
-    );
-  }
+  })();
 
   endPoint.x = Math.max(0, Math.min(endPoint.x, width));
   endPoint.y = Math.max(0, Math.min(endPoint.y, height));
@@ -855,7 +868,7 @@ export const defineActionSwipe = (config: {
   return defineAction<typeof ActionSwipeParamSchema, ActionSwipeParam>({
     name: 'Swipe',
     description:
-      'Perform a touch gesture that directly manipulates the UI (e.g., adjust a continuous control such as a slider or wheel picker, switch between paged cards or images, follow an on-screen swipe gesture to continue or dismiss, or swipe an item to delete it). For browsing off-screen content in a page or scrollable region, use Scroll instead. Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.',
+      'Perform a touch gesture that directly manipulates the UI (e.g., adjust a continuous control such as a slider or wheel picker, switch between paged cards or images, follow an on-screen swipe gesture to continue or dismiss, or swipe an item to delete it). For browsing off-screen content in a page or scrollable region, use Scroll instead. Choose exactly one movement form: (1) relative swipe — provide "direction" and a positive "distance"; or (2) endpoint swipe — provide "end". "start" is optional for both forms and defaults to the center of the page. Do not combine "end" with "direction" or "distance".',
     paramSchema: ActionSwipeParamSchema,
     sample: {
       start: { prompt: 'center of the notification' },

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -638,9 +638,12 @@ export const actionScrollParamSchema = z.object({
     ),
   distance: z
     .number()
+    .positive()
     .nullable()
     .optional()
-    .describe('The distance in pixels to scroll'),
+    .describe(
+      'Positive requested scroll amount in screen-coordinate units. On touch platforms, it controls the length of the swipe gesture used to scroll; on web and desktop platforms, it controls or approximates the wheel scroll delta. Only effective when scrollType is "singleAction".',
+    ),
   locate: getMidsceneLocationSchema()
     .optional()
     .describe(

--- a/packages/core/src/device/index.ts
+++ b/packages/core/src/device/index.ts
@@ -634,7 +634,7 @@ export const actionScrollParamSchema = z.object({
     .enum(['down', 'up', 'right', 'left'])
     .default('down')
     .describe(
-      'The direction to scroll. Only effective when scrollType is "singleAction".',
+      'The direction toward the off-screen content to reveal. "down" reveals content below the current viewport, "up" reveals content above, "right" reveals content to the right, and "left" reveals content to the left. This does not describe the movement direction of the content currently visible on the screen. Only effective when scrollType is "singleAction".',
     ),
   distance: z
     .number()
@@ -654,7 +654,7 @@ export const defineActionScroll = (
   return defineAction<typeof actionScrollParamSchema, ActionScrollParam>({
     name: 'Scroll',
     description:
-      'Scroll the page or a scrollable element to browse content. This is the preferred way to scroll on all platforms, including mobile. Supports scrollToBottom/scrollToTop for boundary navigation. Default: direction `down`, scrollType `singleAction`, distance `null`.',
+      'Scroll a page or scrollable region to reveal off-screen content. Use Scroll when the goal is to browse content outside the current viewport. For direct gesture interactions, such as adjusting a slider or wheel picker, switching between paged cards or images, following an on-screen swipe gesture to continue or dismiss, or swiping an item to delete it, use Swipe instead. Supports scrollToBottom/scrollToTop for boundary navigation. Default: direction `down`, scrollType `singleAction`, distance `null`.',
     interfaceAlias: 'aiScroll',
     paramSchema: actionScrollParamSchema,
     sample: {
@@ -855,7 +855,7 @@ export const defineActionSwipe = (config: {
   return defineAction<typeof ActionSwipeParamSchema, ActionSwipeParam>({
     name: 'Swipe',
     description:
-      'Perform a touch gesture for interactions beyond regular scrolling (e.g., adjust a continuous control such as a slider, flip pages in a carousel, dismiss a notification, swipe-to-delete a list item). For regular content scrolling, use Scroll instead. Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.',
+      'Perform a touch gesture that directly manipulates the UI (e.g., adjust a continuous control such as a slider or wheel picker, switch between paged cards or images, follow an on-screen swipe gesture to continue or dismiss, or swipe an item to delete it). For browsing off-screen content in a page or scrollable region, use Scroll instead. Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.',
     paramSchema: ActionSwipeParamSchema,
     sample: {
       start: { prompt: 'center of the notification' },

--- a/packages/core/tests/unit-test/action-scroll.test.ts
+++ b/packages/core/tests/unit-test/action-scroll.test.ts
@@ -1,0 +1,46 @@
+import { parseActionParam } from '@/ai-model';
+import { actionScrollParamSchema } from '@/device';
+import { describe, expect, it } from '@rstest/core';
+
+describe('Scroll Action Parameter Validation', () => {
+  it('accepts a positive distance', () => {
+    const parsed = parseActionParam(
+      { direction: 'down', distance: 100 },
+      actionScrollParamSchema,
+    );
+
+    expect(parsed).toMatchObject({
+      direction: 'down',
+      distance: 100,
+      scrollType: 'singleAction',
+    });
+  });
+
+  it('rejects a non-positive distance', () => {
+    expect(() =>
+      parseActionParam(
+        { direction: 'down', distance: 0 },
+        actionScrollParamSchema,
+      ),
+    ).toThrow();
+    expect(() =>
+      parseActionParam(
+        { direction: 'down', distance: -100 },
+        actionScrollParamSchema,
+      ),
+    ).toThrow();
+  });
+
+  it('keeps a null distance as the default-distance signal', () => {
+    const parsed = parseActionParam(
+      { direction: 'down', distance: null },
+      actionScrollParamSchema,
+    );
+
+    expect(parsed).toMatchObject({
+      direction: 'down',
+      distance: null,
+      scrollType: 'singleAction',
+    });
+  });
+});

--- a/packages/core/tests/unit-test/action-swipe.test.ts
+++ b/packages/core/tests/unit-test/action-swipe.test.ts
@@ -1,0 +1,105 @@
+import { parseActionParam } from '@/ai-model';
+import { ActionSwipeParamSchema, normalizeMobileSwipeParam } from '@/device';
+import { describe, expect, it } from '@rstest/core';
+
+describe('Swipe Action Parameter Validation', () => {
+  const screenSize = { width: 400, height: 800 };
+  const endpoint = {
+    description: 'swipe endpoint',
+    center: [100, 200] as [number, number],
+  };
+
+  describe('ActionSwipeParamSchema', () => {
+    it('accepts a positive distance', () => {
+      const parsed = parseActionParam(
+        { direction: 'up', distance: 200 },
+        ActionSwipeParamSchema,
+      );
+
+      expect(parsed).toEqual({
+        direction: 'up',
+        distance: 200,
+        duration: 300,
+      });
+    });
+
+    it('rejects a non-positive distance', () => {
+      expect(() =>
+        parseActionParam(
+          { direction: 'up', distance: 0 },
+          ActionSwipeParamSchema,
+        ),
+      ).toThrow();
+      expect(() =>
+        parseActionParam(
+          { direction: 'up', distance: -100 },
+          ActionSwipeParamSchema,
+        ),
+      ).toThrow();
+    });
+  });
+
+  describe('normalizeMobileSwipeParam', () => {
+    it('uses the screen center when an endpoint swipe omits start', () => {
+      const result = normalizeMobileSwipeParam({ end: endpoint }, screenSize);
+
+      expect(result.startPoint).toEqual({ x: 200, y: 400 });
+      expect(result.endPoint).toEqual({ x: 100, y: 200 });
+    });
+
+    it('normalizes a relative swipe with a positive distance', () => {
+      const result = normalizeMobileSwipeParam(
+        { direction: 'up', distance: 150 },
+        screenSize,
+      );
+
+      expect(result.startPoint).toEqual({ x: 200, y: 400 });
+      expect(result.endPoint).toEqual({ x: 200, y: 250 });
+    });
+
+    it('rejects combining end with direction', () => {
+      expect(() =>
+        normalizeMobileSwipeParam(
+          {
+            end: endpoint,
+            direction: 'up',
+          },
+          screenSize,
+        ),
+      ).toThrow(/"end" cannot be combined/);
+    });
+
+    it('rejects combining end with distance', () => {
+      expect(() =>
+        normalizeMobileSwipeParam(
+          {
+            end: endpoint,
+            distance: 150,
+          },
+          screenSize,
+        ),
+      ).toThrow(/"end" cannot be combined/);
+    });
+
+    it('rejects an incomplete relative swipe', () => {
+      expect(() =>
+        normalizeMobileSwipeParam({ direction: 'up' }, screenSize),
+      ).toThrow(/requires both "direction" and a positive "distance"/);
+      expect(() =>
+        normalizeMobileSwipeParam({ distance: 150 }, screenSize),
+      ).toThrow(/requires both "direction" and a positive "distance"/);
+    });
+
+    it('rejects a non-positive distance when called directly', () => {
+      expect(() =>
+        normalizeMobileSwipeParam({ direction: 'up', distance: 0 }, screenSize),
+      ).toThrow(/"distance" must be a positive number/);
+      expect(() =>
+        normalizeMobileSwipeParam(
+          { direction: 'up', distance: -100 },
+          screenSize,
+        ),
+      ).toThrow(/"distance" must be a positive number/);
+    });
+  });
+});

--- a/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
+++ b/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
@@ -502,18 +502,32 @@ describe('buildActionDescription and serializeActionDescriptions', () => {
       'Use Scroll when the goal is to browse content outside the current viewport.',
     );
     expect(action.description).toContain('For direct gesture interactions');
-    expect(action.param.direction.description).toContain(
-      'The direction toward the off-screen content to reveal.',
-    );
-    expect(action.param.direction.description).toContain(
-      '"down" reveals content below the current viewport',
-    );
-    expect(action.param.direction.description).toContain(
-      'This does not describe the movement direction of the content currently visible on the screen.',
-    );
-    expect(action.param.distance.description).toContain(
-      'Positive requested scroll amount in screen-coordinate units.',
-    );
+    expect(action.param).toMatchObject({
+      direction: {
+        description: expect.stringContaining(
+          'The direction toward the off-screen content to reveal.',
+        ),
+      },
+      distance: {
+        description: expect.stringContaining(
+          'Positive requested scroll amount in screen-coordinate units.',
+        ),
+      },
+    });
+    expect(action.param).toMatchObject({
+      direction: {
+        description: expect.stringContaining(
+          '"down" reveals content below the current viewport',
+        ),
+      },
+    });
+    expect(action.param).toMatchObject({
+      direction: {
+        description: expect.stringContaining(
+          'This does not describe the movement direction of the content currently visible on the screen.',
+        ),
+      },
+    });
   });
 
   it('swipe action explains direct gesture controls', () => {

--- a/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
+++ b/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
@@ -525,29 +525,31 @@ describe('buildActionDescription and serializeActionDescriptions', () => {
     expect(action.description).toContain(
       'adjust a continuous control such as a slider or wheel picker',
     );
+    expect(action.description).toContain('Choose exactly one movement form:');
     expect(action.description).toContain(
-      'Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.',
+      'relative swipe — provide "direction" and a positive "distance"',
     );
+    expect(action.description).toContain('endpoint swipe — provide "end"');
     expect(actionSpaceDescription).toMatchInlineSnapshot(`
       "- type: Swipe
-        description: Perform a touch gesture that directly manipulates the UI (e.g., adjust a continuous control such as a slider or wheel picker, switch between paged cards or images, follow an on-screen swipe gesture to continue or dismiss, or swipe an item to delete it). For browsing off-screen content in a page or scrollable region, use Scroll instead. Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.
+        description: 'Perform a touch gesture that directly manipulates the UI (e.g., adjust a continuous control such as a slider or wheel picker, switch between paged cards or images, follow an on-screen swipe gesture to continue or dismiss, or swipe an item to delete it). For browsing off-screen content in a page or scrollable region, use Scroll instead. Choose exactly one movement form: (1) relative swipe — provide "direction" and a positive "distance"; or (2) endpoint swipe — provide "end". "start" is optional for both forms and defaults to the center of the page. Do not combine "end" with "direction" or "distance".'
         param:
           start:
             type: '{ prompt: string /* description of the target element */ }'
             optional: true
-            description: Starting point of the swipe gesture, if not specified, the center of the page will be used
+            description: Optional starting point of the finger movement. Available in both relative and endpoint forms. If omitted, the center of the page is used.
           direction:
             type: enum('up', 'down', 'left', 'right')
             optional: true
-            description: The direction to swipe (required when using distance). The direction means the direction of the finger swipe.
+            description: Finger movement direction. Required together with a positive distance for a relative swipe. Omit when using end.
           distance:
             type: number
             optional: true
-            description: The distance in pixels to swipe (mutually exclusive with end)
+            description: Positive length of the finger movement in pixels. Required together with direction for a relative swipe. Omit when using end.
           end:
             type: '{ prompt: string /* description of the target element */ }'
             optional: true
-            description: Ending point of the swipe gesture (mutually exclusive with distance)
+            description: Endpoint of the finger movement. Use for an endpoint swipe, optionally with start. Do not provide direction or distance when using end.
           duration:
             type: number
             optional: true

--- a/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
+++ b/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
@@ -11,6 +11,7 @@ import type { LocateResultPromptSpec } from '@/ai-model/shared/model-locate-resu
 import {
   defineActionInput,
   defineActionKeyboardPress,
+  defineActionScroll,
   defineActionSwipe,
 } from '@/device';
 import { getMidsceneLocationSchema } from '@/index';
@@ -492,7 +493,27 @@ describe('buildActionDescription and serializeActionDescriptions', () => {
     `);
   });
 
-  it('swipe action explains touch slider use', () => {
+  it('scroll action defines direction by the content to reveal', () => {
+    const { actionDescription: action } = buildActionDescriptions(
+      defineActionScroll(async () => {}),
+    );
+
+    expect(action.description).toContain(
+      'Use Scroll when the goal is to browse content outside the current viewport.',
+    );
+    expect(action.description).toContain('For direct gesture interactions');
+    expect(action.param.direction.description).toContain(
+      'The direction toward the off-screen content to reveal.',
+    );
+    expect(action.param.direction.description).toContain(
+      '"down" reveals content below the current viewport',
+    );
+    expect(action.param.direction.description).toContain(
+      'This does not describe the movement direction of the content currently visible on the screen.',
+    );
+  });
+
+  it('swipe action explains direct gesture controls', () => {
     const { actionDescription: action, actionSpaceDescription } =
       buildActionDescriptions(
         defineActionSwipe({
@@ -502,14 +523,14 @@ describe('buildActionDescription and serializeActionDescriptions', () => {
       );
 
     expect(action.description).toContain(
-      'adjust a continuous control such as a slider',
+      'adjust a continuous control such as a slider or wheel picker',
     );
     expect(action.description).toContain(
       'Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.',
     );
     expect(actionSpaceDescription).toMatchInlineSnapshot(`
       "- type: Swipe
-        description: Perform a touch gesture for interactions beyond regular scrolling (e.g., adjust a continuous control such as a slider, flip pages in a carousel, dismiss a notification, swipe-to-delete a list item). For regular content scrolling, use Scroll instead. Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.
+        description: Perform a touch gesture that directly manipulates the UI (e.g., adjust a continuous control such as a slider or wheel picker, switch between paged cards or images, follow an on-screen swipe gesture to continue or dismiss, or swipe an item to delete it). For browsing off-screen content in a page or scrollable region, use Scroll instead. Use "distance" + "direction" for relative movement, or "start" + "end" for precise endpoint movement.
         param:
           start:
             type: '{ prompt: string /* description of the target element */ }'

--- a/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
+++ b/packages/core/tests/unit-test/prompt/planning/action-description.test.ts
@@ -511,6 +511,9 @@ describe('buildActionDescription and serializeActionDescriptions', () => {
     expect(action.param.direction.description).toContain(
       'This does not describe the movement direction of the content currently visible on the screen.',
     );
+    expect(action.param.distance.description).toContain(
+      'Positive requested scroll amount in screen-coordinate units.',
+    );
   });
 
   it('swipe action explains direct gesture controls', () => {


### PR DESCRIPTION
Scroll and Swipe direction semantics were easy for the planner to confuse, especially for wheel pickers, gesture overlays, and paged controls. Invalid Swipe parameter combinations and non-positive distances could also reach action execution.

This change:
- defines `Scroll.direction` as the direction of off-screen content to reveal;
- defines `Swipe.direction` as the finger movement direction and recommends Swipe for direct gesture controls;
- documents and validates the two Swipe parameter forms: `direction + positive distance`, or `end` with an optional `start`;
- requires positive `Scroll.distance` and clarifies its cross-platform input semantics;
- adds focused unit coverage for parameter validation and serialized Action Space descriptions.

Validation:
- `pnpm run lint`
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit --pretty false`
- `pnpm --filter @midscene/core test -- tests/unit-test/action-swipe.test.ts tests/unit-test/prompt/planning/action-description.test.ts`
- `pnpm --filter @midscene/core test -- tests/unit-test/action-scroll.test.ts tests/unit-test/prompt/planning/action-description.test.ts`
- `pnpm exec nx build @midscene/core`