### PR TITLE
fix(test): support running a single YAML file

### DIFF
--- a/packages/test/src/cli/test-command.ts
+++ b/packages/test/src/cli/test-command.ts
@@ -37,8 +37,7 @@ export const parseTestCliArgs = (
   for (let index = commandOffset; index < args.length; index += 1) {
     const arg = args[index];
     if (!arg.startsWith('-')) {
-      if (projectRoot)
-        throw new Error('Only one test project directory is allowed.');
+      if (projectRoot) throw new Error('Only one test path is allowed.');
       projectRoot = resolve(cwd, arg);
       continue;
     }

--- a/packages/test/src/cli/test-project-runner.ts
+++ b/packages/test/src/cli/test-project-runner.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { setMaxListeners } from 'node:events';
 import { existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
-import { join, relative, resolve, sep } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { TestRunReportAssembler } from '@midscene/core/report';
 import { globSync } from 'tinyglobby';
 import { createProjectRuntime } from '../engine/project-runtime';
@@ -128,6 +128,17 @@ export const discoverTestConfig = (projectRoot: string): string | undefined => {
     );
   }
   return candidates.includes(CONFIG_NAME) ? join(root, CONFIG_NAME) : undefined;
+};
+
+const discoverTestConfigFromFile = (testFile: string): string | undefined => {
+  let directory = dirname(testFile);
+  while (true) {
+    const configPath = discoverTestConfig(directory);
+    if (configPath) return configPath;
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
 };
 
 const defaultResultDir = (projectRoot: string): string =>
@@ -295,9 +306,14 @@ const prepareProject = <TProjectContext>(
   project: LoadedExecutionProject<TProjectContext>,
   projectRoot: string,
   runDir: string,
+  testFile?: string,
 ): PreparedExecutionProject<TProjectContext> => {
-  const fileSelection = project.files ?? DEFAULT_TEST_FILE_SELECTION;
-  const files = discoverTestFiles(projectRoot, fileSelection);
+  const fileSelection = testFile
+    ? { include: [toPosix(relative(projectRoot, testFile))] }
+    : (project.files ?? DEFAULT_TEST_FILE_SELECTION);
+  const files = testFile
+    ? [testFile]
+    : discoverTestFiles(projectRoot, fileSelection);
   const sources = files.map((absolutePath) => ({
     projectId: project.projectId,
     projectName: project.name,
@@ -375,20 +391,40 @@ export async function runTestProject(
   const runId = createTestRunId(startedAt);
   const cwd = resolve(options.cwd ?? process.cwd());
   assertDirectory(cwd, 'Test working directory');
-  const cliProjectRoot = options.projectRoot
+  const testPath = options.projectRoot
     ? resolve(cwd, options.projectRoot)
     : undefined;
-  if (cliProjectRoot) assertDirectory(cliProjectRoot, 'Test project directory');
-  const configSearchRoot = cliProjectRoot ?? cwd;
+  if (testPath && !existsSync(testPath)) {
+    if (/\.ya?ml$/i.test(testPath)) {
+      throw new Error(`Test file does not exist: ${testPath}`);
+    }
+    assertDirectory(testPath, 'Test project directory');
+  }
+  const testPathStats = testPath ? statSync(testPath) : undefined;
+  const testFile = testPathStats?.isFile() ? testPath : undefined;
+  if (testFile && !/\.ya?ml$/i.test(testFile)) {
+    throw new Error(`Test file must be a .yaml or .yml file: ${testFile}`);
+  }
+  if (testPath && !testPathStats?.isDirectory() && !testFile) {
+    throw new Error(`Test path is not a directory or YAML file: ${testPath}`);
+  }
+  const cliProjectRoot = testPathStats?.isDirectory() ? testPath : undefined;
+  const configSearchRoot = testFile
+    ? dirname(testFile)
+    : (cliProjectRoot ?? cwd);
   const configPath = options.configPath
     ? resolve(configSearchRoot, options.configPath)
-    : discoverTestConfig(configSearchRoot);
+    : testFile
+      ? discoverTestConfigFromFile(testFile)
+      : discoverTestConfig(configSearchRoot);
   if (options.configPath && (!configPath || !existsSync(configPath))) {
     throw new Error(`Midscene config does not exist: ${configPath}`);
   }
 
   const definition = await loadTestProject(configPath);
-  const projectRoot = cliProjectRoot ?? cwd;
+  const projectRoot =
+    cliProjectRoot ??
+    (configPath ? dirname(configPath) : testFile ? dirname(testFile) : cwd);
 
   const resultDir = options.resultDir
     ? resolve(cwd, options.resultDir)
@@ -403,7 +439,7 @@ export async function runTestProject(
     options.projectNames,
   );
   const preparedProjects = selectedProjects.map((project) =>
-    prepareProject(project, projectRoot, runDir),
+    prepareProject(project, projectRoot, runDir, testFile),
   );
   const progress = options.onProgress ?? (() => {});
   const totalDocuments = preparedProjects.reduce(

--- a/packages/test/tests/e2e/test-cli.test.ts
+++ b/packages/test/tests/e2e/test-cli.test.ts
@@ -193,6 +193,49 @@ describe('midscene-test CLI', () => {
     });
   });
 
+  it('runs only the requested workflow document', async () => {
+    const projectRoot = join(__dirname, 'fixtures', 'test-project');
+    const workflowPath = join(projectRoot, 'flows', 'first.yaml');
+    const { resultDir, executionLog } = temporaryRun(
+      'midscene-single-file-e2e-',
+    );
+
+    const execution = await execFileAsync(
+      process.execPath,
+      [cliPath, workflowPath, '--result-dir', resultDir],
+      {
+        cwd: packageRoot,
+        env: { ...process.env, WORKFLOW_E2E_LOG: executionLog },
+      },
+    );
+
+    expect(execution.stdout).toContain(
+      'midscene-test: preflighted 1 projects, 1 documents, 2 cases, 0 collection errors',
+    );
+    expect(execution.stdout).toContain('[document 1/1] flows/first.yaml');
+    expect(execution.stdout).not.toContain('flows/nested/second.yml');
+    expect(readFileSync(executionLog, 'utf8').trim().split('\n')).toEqual([
+      'first:one',
+      'first:two',
+      'second:one',
+    ]);
+
+    const projectResult = JSON.parse(
+      readFileSync(summaryPathFor(resultDir), 'utf8'),
+    );
+    expect(projectResult).toMatchObject({
+      projectRoot,
+      projects: [
+        {
+          name: 'web',
+          sourceCount: 1,
+          fileSelection: { include: ['flows/first.yaml'] },
+          cases: [{ name: 'first case' }, { name: 'second case' }],
+        },
+      ],
+    });
+  });
+
   it('describes registered nodes without reading workflows or running setup', async () => {
     const projectRoot = mkdtempSync(join(packageRoot, '.node-reference-e2e-'));
     temporaryDirectories.push(projectRoot);

--- a/packages/test/tests/nodes.test.ts
+++ b/packages/test/tests/nodes.test.ts
@@ -101,6 +101,18 @@ describe('nodes', () => {
     expect(io.error).not.toHaveBeenCalled();
   });
 
+  it('continues to require a directory as its positional argument', async () => {
+    const root = createProject();
+    const workflowPath = join(root, 'example.yaml');
+    writeFileSync(workflowPath, 'cases: []');
+    const io = { log: vi.fn(), error: vi.fn() };
+
+    expect(await runTestCli(['nodes', workflowPath], io)).toBe(1);
+    expect(io.error).toHaveBeenCalledWith(
+      `Test project directory does not exist or is not a directory: ${workflowPath}`,
+    );
+  });
+
   it('writes in the test directory when a custom config is specified', async () => {
     const root = createProject();
     mkdirSync(join(root, 'config'));

--- a/packages/test/tests/test-project-runner.test.ts
+++ b/packages/test/tests/test-project-runner.test.ts
@@ -3,6 +3,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -16,7 +17,7 @@ import {
   discoverTestFiles,
   runTestProject,
 } from '../src/cli';
-import { parseTestCliArgs } from '../src/cli/test-command';
+import { parseTestCliArgs, runTestCli } from '../src/cli/test-command';
 
 interface RunnerState {
   configLoads: number;
@@ -392,6 +393,122 @@ describe('test project main-process runner', () => {
     expect(projectResult.projects[0].fileSelection).toEqual({
       include: ['**/*.{yaml,yml}'],
     });
+  });
+
+  it.each(['yaml', 'yml'])(
+    'runs only an explicit .%s file and discovers config from its ancestors',
+    async (extension) => {
+      const root = createProject();
+      const resultDir = join(root, 'results');
+      const targetPath = join(root, 'cases', `target.${extension}`);
+      writeFileSync(
+        join(root, 'midscene.config.ts'),
+        `export default {
+          projects: [
+            { name: 'selected', files: { include: ['cases/ignored.yaml'] } },
+            { name: 'other' },
+          ],
+          nodes: [{ name: 'noop', stringInputKey: 'prompt', execute() {} }],
+        };`,
+      );
+      writeWorkflow(
+        root,
+        `cases/target.${extension}`,
+        'cases: [{ name: target, steps: [{ noop: run }] }]',
+      );
+      writeWorkflow(root, 'cases/ignored.yaml', 'cases: invalid');
+      const errors: string[] = [];
+
+      const exitCode = await runTestCli(
+        [targetPath, '--project', 'selected', '--result-dir', resultDir],
+        { log() {}, error: (message) => errors.push(message) },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(errors).toEqual([]);
+      const [runId] = readdirSync(resultDir);
+      const summary = JSON.parse(
+        readFileSync(join(resultDir, runId, 'summary.json'), 'utf8'),
+      );
+      expect(summary).toMatchObject({
+        projectRoot: root,
+        projects: [
+          {
+            name: 'selected',
+            sourceCount: 1,
+            fileSelection: {
+              include: [`cases/target.${extension}`],
+            },
+            cases: [
+              { name: 'target', sourcePath: `cases/target.${extension}` },
+            ],
+          },
+        ],
+      });
+    },
+  );
+
+  it('uses the file parent as the project root when no config is found', async () => {
+    const root = createProject();
+    const resultDir = join(root, 'results');
+    const targetPath = join(root, 'cases', 'empty.yaml');
+    writeWorkflow(root, 'cases/empty.yaml', 'cases: []');
+
+    const result = await runTestProject({
+      projectRoot: targetPath,
+      resultDir,
+    });
+
+    const summary = JSON.parse(readFileSync(result.summaryPath, 'utf8'));
+    expect(summary.projectRoot).toBe(dirname(targetPath));
+    expect(result.projects[0].sourceCount).toBe(1);
+  });
+
+  it('rejects a missing positional test path', async () => {
+    const root = createProject();
+    const missingPath = join(root, 'missing.yaml');
+    const errors: string[] = [];
+
+    expect(
+      await runTestCli([missingPath], {
+        log() {},
+        error: (message) => errors.push(message),
+      }),
+    ).toBe(1);
+    expect(errors).toEqual([`Test file does not exist: ${missingPath}`]);
+  });
+
+  it('preserves the missing project directory error', async () => {
+    const root = createProject();
+    const missingPath = join(root, 'missing-directory');
+    const errors: string[] = [];
+
+    expect(
+      await runTestCli([missingPath], {
+        log() {},
+        error: (message) => errors.push(message),
+      }),
+    ).toBe(1);
+    expect(errors).toEqual([
+      `Test project directory does not exist or is not a directory: ${missingPath}`,
+    ]);
+  });
+
+  it('rejects a non-YAML positional test file', async () => {
+    const root = createProject();
+    const textPath = join(root, 'notes.txt');
+    writeFileSync(textPath, 'not yaml');
+    const errors: string[] = [];
+
+    expect(
+      await runTestCli([textPath], {
+        log() {},
+        error: (message) => errors.push(message),
+      }),
+    ).toBe(1);
+    expect(errors).toEqual([
+      `Test file must be a .yaml or .yml file: ${textPath}`,
+    ]);
   });
 
   it('reports live document, case, and step progress', async () => {


### PR DESCRIPTION
## Summary

- accept a single `.yaml` or `.yml` file as the `midscene-test` positional argument
- discover the nearest `midscene.config.ts` from the selected file and run only that workflow document
- preserve directory execution, execution-project filtering, and the directory-only `nodes` command
- report clear errors for missing YAML files and unsupported file types
- add unit and real CLI end-to-end coverage for single-file execution

## Validation

- `pnpm run lint`
- `pnpm exec nx test @midscene/test --skip-nx-cache --output-style=static` (331 tests passed)
- `pnpm exec nx build @midscene/test --skip-nx-cache --output-style=static`
- `pnpm --filter @midscene/test exec vitest --run --config vitest.e2e.config.ts tests/e2e/test-cli.test.ts` (9 tests passed)
- `git diff --check`

Fixes #3132
